### PR TITLE
Add contributor onboarding: CONTRIBUTING, SECURITY, templates, CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Something isn't working
+labels: bug
+---
+
+## What happened
+
+<!-- Concise description of the actual behavior. -->
+
+## What you expected
+
+<!-- What you expected to happen instead. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- OnionPress version: <!-- e.g. v2.4.75 — visible at the top of WP admin or via `onionpress-cli status` -->
+- OS: <!-- macOS 14.x / Ubuntu 24.04 / Debian 12 / etc. -->
+- Architecture: <!-- arm64 / x86_64 -->
+- Install method: <!-- DMG / .deb / AppImage -->
+
+## Logs
+
+<!-- Relevant lines from ~/.onionpress/onionpress.log (or /var/log/onionpress/ on Linux). -->
+<!-- If logs are long, please paste a snippet around the time of the issue rather than the whole file. -->
+<!-- Redact onion addresses and email addresses if you'd prefer not to share them publicly. -->
+
+```
+```
+
+## Anything else
+
+<!-- Screenshots, related issues, things you've already tried. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/brewsterkahle/onionpress/security/advisories/new
+    about: Please report security issues privately, not in a public issue. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest a new capability or improvement
+labels: enhancement
+---
+
+## The problem
+
+<!-- What are you trying to do that OnionPress makes hard or impossible today? -->
+
+## Proposal
+
+<!-- A concrete description of the change you'd like to see.
+     Sketches of UI, command-line shape, or JSON output are great. -->
+
+## Alternatives considered
+
+<!-- What other approaches did you think about, and why is the proposal better? -->
+
+## Out of scope
+
+<!-- (Optional) Things this issue explicitly does NOT cover, so reviewers
+     don't expand the scope unintentionally. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--
+Thanks for the contribution. A few notes before you submit:
+- One logical change per PR. Drive-by cleanups are easier to review as separate PRs.
+- Update or add tests where it makes sense.
+- The CI workflow will run unit tests automatically.
+-->
+
+## Summary
+
+<!-- 1-3 sentences. The "why" of this change. -->
+
+## Changes
+
+<!-- Bulleted list of what this PR does. -->
+
+-
+
+## Test plan
+
+<!-- How you verified this works. Commands you ran, manual steps you took. -->
+
+- [ ]
+- [ ]
+
+## Related issue
+
+<!-- e.g. "Closes #123" or "Refs #456". Leave blank if no related issue. -->

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    name: Python unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run tests
+        run: python -m unittest tests.test_onionpress_cli -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,176 @@
+# Contributing to OnionPress
+
+Thanks for your interest in contributing. OnionPress is a single-maintainer
+project today, transitioning to take outside contributions. This document
+covers what you need to know.
+
+## What OnionPress is
+
+A consumer-friendly way to publish a WordPress site as a Tor onion service.
+On macOS it ships as a menubar app; on Linux as a `.deb` / AppImage with a
+systemd service. WordPress, MariaDB, and Tor run as Docker containers
+(inside Colima on macOS, native Docker on Linux). The host-side wrapper
+handles startup, port detection, key management, backups, and updates.
+
+## Repo layout
+
+| Path | What lives there |
+| --- | --- |
+| `src/menubar.py` | The macOS menubar app (`py2app` entry point). |
+| `src/onionpress/` | Shared Python package — CLI, updater, backup, OnionHeaven, key management, etc. |
+| `app/` | macOS `.app` bundle source (assembled into `OnionPress.app/` at build time). |
+| `linux/` | Linux launcher script and systemd units. |
+| `app/Resources/plugins/` | WordPress plugins (mu-plugins) shipped with the app. |
+| `app/Resources/docker/` | Docker Compose file and per-container configs. |
+| `tests/` | Python unit tests (pytest / unittest). |
+| `build/` | Build scripts (DMG, .deb, AppImage, version bumping). |
+
+## Naming and terminology
+
+- The project is **OnionPress** (one word, capital O and P). Never "Onion.Press"
+  or "onion.press".
+- Use **"onion service"**, not "hidden service" — the Tor Project deprecated
+  that term. (The exception is unavoidable external identifiers like the
+  `goldy/tor-hidden-service` Docker image name.)
+- Data directory is `~/.onionpress/`. User-visible content lives in
+  `~/Documents/OnionPress/`.
+
+## Setting up a dev environment (macOS)
+
+1. Install Python 3.14 from python.org (or homebrew). `py2app` needs the
+   universal2 build, which the python.org installer provides.
+2. `git clone` the repo and `cd` into it.
+3. Run the existing tests to confirm your environment works:
+
+   ```
+   python3 -m unittest tests.test_onionpress_cli
+   ```
+
+4. To rebuild the menubar app after editing `src/`:
+
+   ```
+   build/rebuild-menubar.sh
+   ```
+
+   This takes a couple of minutes. After running, **quit and relaunch
+   `OnionPress.app`** — `src/` edits don't take effect in the running
+   process, only in a fresh launch.
+
+5. To launch from a clean state:
+
+   ```
+   /Applications/OnionPress.app/Contents/MacOS/onionpress-cli quit
+   open /Applications/OnionPress.app
+   ```
+
+## Setting up a dev environment (Linux)
+
+The Linux build is scripts-only (no compiled binaries). `build/build-linux.sh`
+produces a `.deb` and an AppImage. Test the launcher directly:
+
+```
+linux/onionpress start
+linux/onionpress logs
+linux/onionpress stop
+```
+
+Containers run via native Docker, no Colima.
+
+## Running tests
+
+Unit tests live in `tests/`. Run with either runner:
+
+```
+python3 -m unittest tests.test_onionpress_cli       # builtin
+pytest tests/                                        # if installed
+```
+
+CI runs the same tests on every PR; broken tests block merge.
+
+## Code style
+
+- **Default to no comments.** The codebase generally avoids comments that
+  describe what code does. Reserve comments for the *why* — non-obvious
+  constraints, workarounds for specific bugs, or invariants that aren't
+  visible from the code.
+- **Don't add error handling for impossible cases.** Trust internal calls
+  and framework guarantees. Only validate at system boundaries (user
+  input, external APIs, container output).
+- **`subprocess.run` reading `.stdout`/`.stderr` MUST use
+  `text=True, encoding='utf-8', errors='replace'`** — without this,
+  non-ASCII characters from Tor logs (✓, —) cause crashes. Calls that
+  only check `.returncode` and discard output are fine without it.
+- **Database passwords are randomly generated per-install.** Never use
+  defaults or hardcoded passwords. Don't commit or log passwords.
+- **No clearnet requests from Docker containers.** Anything reaching
+  outside the local machine must go through Tor SOCKS (`socks5h://onionpress-tor:9050`
+  inside containers, the WordPress container's `onionpress_curl_tor()`
+  helper for PHP). Direct curl to `https://archive.org` etc. is a leak
+  bug, not a convenience.
+
+## Making a change
+
+1. Open an issue first for anything beyond a small fix, so we can
+   discuss approach before you spend time. Pre-existing tagged
+   "good first issue" items already have agreed scope.
+2. Fork the repo and create a branch off `main`.
+3. Make your change. Keep PRs focused — one logical change per PR.
+4. Update or add tests where it makes sense.
+5. Commit with a descriptive message. Follow the existing style:
+   short subject (under 70 chars), then a blank line, then a body
+   explaining the *why*. Reference issues with `(#NNN)`.
+6. Open a PR against `main`. The PR template will ask you to describe
+   the change, link the issue, and explain how you tested it.
+7. CI will run the unit tests. If they fail, fix them before review.
+
+## Things that stay with the maintainer
+
+These aren't open to contributors, at least for now:
+
+- **Cutting releases.** Release tagging, DMG signing/notarization, and
+  upload to GitHub Releases require credentials only the maintainer has.
+- **`.github/workflows/docker-publish.yml`** — controls what
+  `ghcr.io/brewsterkahle/onionpress-*` images contain. Supply chain;
+  changes go through extra review.
+- **The OnionHeaven hub registration protocol.** Changes affect every
+  running install; coordinate with the maintainer before touching it.
+
+You're welcome to propose changes to all of these via PR — merge stays
+with the maintainer.
+
+## Build pipeline gotchas
+
+- **`py2app` vs `setuptools` 81+** — setuptools 81 (released 2026-02-06)
+  removed `dry_run` from `distutils.spawn()`, which py2app 0.28.9 still
+  uses. `build/build-dmg-simple.sh` handles this with a fallback to
+  `setuptools<81`. If you hit a similar issue locally, check that.
+- **Bundled Python.** Modern macOS doesn't ship a usable Python.
+  py2app embeds the interpreter. Anywhere shell code runs Python, it
+  must use the bundled binary at
+  `OnionPress.app/Contents/Resources/MenubarApp/Contents/MacOS/python`,
+  never the system `python3`.
+- **Two `Info.plist` files.** `OnionPress.app/Contents/Info.plist`
+  (the parent) and `OnionPress.app/Contents/Resources/MenubarApp/Contents/Info.plist`
+  (py2app's) must agree. `build/rebuild-menubar.sh` syncs them; if you
+  bypass it, expect the WP page to show a stale version.
+
+## Reporting bugs
+
+For non-security bugs, open an issue with the
+[bug report template](.github/ISSUE_TEMPLATE/bug_report.md). Include
+your OS version, OnionPress version (visible at the top of WP admin
+or via `onionpress-cli status`), and the relevant log lines from
+`~/.onionpress/onionpress.log`.
+
+For security issues, see [SECURITY.md](SECURITY.md) — please report
+privately, not in a public issue.
+
+## Asking questions
+
+GitHub Discussions or issues with the "question" label are fine.
+Real-time chat doesn't exist yet.
+
+## License
+
+By contributing, you agree your contribution is licensed under the
+same terms as the project (see [LICENSE](LICENSE)).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,102 @@
+# Security
+
+OnionPress is software that helps people publish on Tor. Bugs that could
+expose a publisher's identity, leak content out of Tor, or weaken the
+isolation between containers are taken seriously.
+
+## Reporting a vulnerability
+
+**Please report privately.** Don't open a public GitHub issue for security
+bugs.
+
+Two channels, in order of preference:
+
+1. **GitHub Security Advisory** — open a private advisory at
+   <https://github.com/brewsterkahle/onionpress/security/advisories/new>.
+   This is the preferred channel; it's encrypted, only visible to the
+   maintainer, and has a clean disclosure-coordination workflow.
+
+2. **Email** — `brewster@archive.org`. Mention "OnionPress security" in the
+   subject. PGP is available on request.
+
+## What we'll do
+
+- Acknowledge your report within **3 business days**.
+- Investigate and reply with an initial assessment within **7 days**.
+- Coordinate disclosure with you. Most fixes ship in the next regular
+  release; if a bug is being actively exploited, we'll cut an emergency
+  release.
+- Credit you in the release notes if you'd like that (or keep your report
+  anonymous if you'd prefer).
+
+## What's in scope
+
+- The macOS menubar app (`src/menubar.py`, `src/onionpress/`,
+  `app/MacOS/`).
+- The Linux launcher (`linux/`).
+- WordPress mu-plugins shipped with OnionPress (`app/Resources/plugins/`).
+- The Docker container configurations
+  (`app/Resources/docker/{tor,wordpress}/`).
+- The OnionHeaven hub protocol and our heartbeat client.
+- The auto-update flow (DMG download, signature checking, install).
+
+In particular, please report:
+
+- Anything that could leak an onion service publisher's IP or real-world
+  identity.
+- Clearnet requests from inside containers that should go via Tor (the
+  "no clearnet" rule — `socks5h://onionpress-tor:9050` inside containers,
+  `onionpress_curl_tor()` for PHP).
+- Persistent or stored XSS in the OnionPress-shipped WordPress plugins.
+- Privilege escalation between containers, or container → host escapes
+  via our shared mounts (`~/.onionpress/shared`, `~/Documents/OnionPress`).
+- Authentication bypass in the WP admin auto-login flow or the
+  OnionHeaven registration protocol.
+- Tampering attacks against the auto-update path (replace the DMG between
+  download and install, etc.).
+
+## What's out of scope
+
+- WordPress core / third-party plugin vulnerabilities. Report those to
+  the WordPress security team or the relevant plugin author. We track
+  upstream advisories and ship updated images, but the bugs themselves
+  aren't ours to fix.
+- Tor Project software (Arti, C Tor, the bundled `tor` binary). Report
+  those to Tor.
+- Docker, Colima, or Lima vulnerabilities. Same — upstream reports.
+- Issues that require physical access to the user's Mac, or that
+  require the attacker to already have root on the user's machine.
+- Theoretical timing attacks against `tor` itself (Tor's threat model
+  documents what it does and doesn't defend against).
+
+## Threat model
+
+Quick summary of who we try to defend against:
+
+- **Network adversaries** observing traffic between the publisher's
+  machine and the rest of the internet. Tor handles this; OnionPress
+  must not bypass Tor.
+- **Visitors** to the onion site. They shouldn't be able to deanonymize
+  the publisher, escape to the host, or escalate from a low-privilege
+  WP account to admin.
+- **Adversaries with physical access** to the publisher's Mac during
+  short absences. This is mostly out of scope (full-disk encryption is
+  the user's responsibility), but we shouldn't make it easier — e.g.
+  no plaintext credentials in `~/.onionpress/` that aren't already
+  loaded by Docker for the running containers.
+
+What we **do not** defend against:
+
+- Running OnionPress on a compromised machine. If the OS is owned, so
+  is OnionPress.
+- Users who deliberately weaken security (e.g. exporting their onion
+  service private key, sharing their database password).
+- Side-channel attacks that have only theoretical proofs of concept;
+  we'll triage but probably won't ship a fix until they're practical.
+
+## Responsible disclosure
+
+Please give us a reasonable window to fix and ship before public
+disclosure. The default is **90 days from the date we acknowledge your
+report**. We'll work with you on the timeline if a fix needs more time
+or if there's reason to disclose sooner.


### PR DESCRIPTION
## Summary

First step in opening OnionPress to outside contributors. Adds the documentation, templates, and CI workflow that a stranger needs to make a useful PR.

## Changes

- **`CONTRIBUTING.md`** — dev env setup (macOS + Linux), repo layout, naming rules, code-style invariants from CLAUDE.md rewritten for humans, build pipeline gotchas, and what stays with the maintainer (releases, docker-publish workflow).
- **`SECURITY.md`** — private reporting via GitHub Security Advisories or `brewster@archive.org`. Scope: Tor leaks, container escapes, auto-update tampering. Out of scope: WP core, Tor itself. 90-day responsible-disclosure default.
- **Issue templates** (bug, feature) + **PR template** so contributors have a known shape.
- **`.github/ISSUE_TEMPLATE/config.yml`** routes "Security vulnerability" to the private advisory form, away from public issues.
- **`.github/workflows/test.yml`** runs the existing 16-test unittest suite on every PR and push. Foundation for branch protection requiring green CI before merge.

## Test plan

- [x] `python3 -m unittest tests.test_onionpress_cli` passes locally (16/16).
- [x] Workflow YAML lints — will run for real on this PR after push.
- [ ] Verify the workflow run is green on this PR.
- [ ] After merge, enable branch protection on `main` requiring this check.

## Followup (separate work)

- Decide on collaborator trust model (forks-and-PRs vs Triage vs Write).
- Add `CODEOWNERS` once there are people to assign.
- Tag a few existing issues with "good first issue" once #216, #217, #212 are out of the way (they are).

🤖 Generated with [Claude Code](https://claude.com/claude-code)