### PR TITLE
Launcher: install Mastodon and Bluesky social-archive importers

### DIFF
--- a/app/MacOS/onionpress
+++ b/app/MacOS/onionpress
@@ -1574,19 +1574,22 @@ chown www-data:www-data /var/www/html/.htaccess' >> "$LOG_FILE" 2>&1 && \
         fi
     fi
 
-    # Copy social-archive Twitter importer mu-plugin — adds Twitter/X
-    # takeout ZIP import under the Social Archive admin menu.
-    if [ -f "$plugins_dir/onionpress-social-archive-twitter.php" ]; then
-        if docker cp "$plugins_dir/onionpress-social-archive-twitter.php" \
-            onionpress-wordpress:/var/www/html/wp-content/mu-plugins/onionpress-social-archive-twitter.php >> "$LOG_FILE" 2>&1; then
-            docker exec onionpress-wordpress chown www-data:www-data \
-                /var/www/html/wp-content/mu-plugins/onionpress-social-archive-twitter.php >> "$LOG_FILE" 2>&1 \
-                || log "WARNING: Failed to chown onionpress-social-archive-twitter.php"
-            log "✓ onionpress-social-archive-twitter.php mu-plugin installed"
-        else
-            log "WARNING: Failed to copy onionpress-social-archive-twitter.php"
+    # Copy social-archive importer mu-plugins (Twitter ZIP import,
+    # Mastodon API import, Bluesky API import — all show up under the
+    # Social Archive admin menu).
+    for importer in twitter mastodon bluesky; do
+        src="$plugins_dir/onionpress-social-archive-${importer}.php"
+        dest="/var/www/html/wp-content/mu-plugins/onionpress-social-archive-${importer}.php"
+        if [ -f "$src" ]; then
+            if docker cp "$src" "onionpress-wordpress:$dest" >> "$LOG_FILE" 2>&1; then
+                docker exec onionpress-wordpress chown www-data:www-data "$dest" >> "$LOG_FILE" 2>&1 \
+                    || log "WARNING: Failed to chown onionpress-social-archive-${importer}.php"
+                log "✓ onionpress-social-archive-${importer}.php mu-plugin installed"
+            else
+                log "WARNING: Failed to copy onionpress-social-archive-${importer}.php"
+            fi
         fi
-    fi
+    done
 
     return 0
 }

--- a/linux/onionpress
+++ b/linux/onionpress
@@ -694,6 +694,10 @@ chown www-data:www-data /var/www/html/.htaccess' >> "$LOG_FILE" 2>&1 && \
         "onionpress-avatar.php"
         "onionpress-blogroll.php"
         "onionpress-status-hint.php"
+        "onionpress-social-archive.php"
+        "onionpress-social-archive-twitter.php"
+        "onionpress-social-archive-mastodon.php"
+        "onionpress-social-archive-bluesky.php"
     )
 
     docker exec onionpress-wordpress mkdir -p \


### PR DESCRIPTION
## Summary

Fresh OnionPress installs were missing the Mastodon and Bluesky import plugins entirely.

## Changes

- **macOS launcher** (\`app/MacOS/onionpress\`): the mu-plugin install block at line 1577-1589 only copied the Twitter importer. Replaced the Twitter-only block with a small loop over \`twitter/mastodon/bluesky\`.
- **Linux launcher** (\`linux/onionpress\`): the \`mu_plugins\` array at line 680-697 was missing all four social-archive plugins (core CPT registrar plus the three importers). Added them.

## Impact

Without this fix, a fresh install on either platform shows up with the Social Archive admin menu present but only Twitter import working — Mastodon and Bluesky imports were impossible until someone manually copied the plugin files into the WordPress container.

This machine has all four because they got copied in over time during dev iterations; new installs hit a blank wall.

## Test plan

- [x] \`bash -n\` syntax check on both files.
- [x] CI runs the existing Python test suite.
- [ ] After merge, verify a fresh-install path picks up all four plugins. (Spot-check: the next time someone runs a clean install, the Social Archive menu should show all three platform tabs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)