### PR TITLE
Settings: reject unresolvable Follow inputs instead of saving as ghost

### DIFF
--- a/app/Resources/plugins/onionpress-settings.php
+++ b/app/Resources/plugins/onionpress-settings.php
@@ -408,6 +408,7 @@ add_action( 'admin_init', function () {
         $resolved_name = '';
         $feed_url = '';
 
+        $addr = '';
         if ( preg_match( '/([a-z2-7]{56}\.onion)/i', $raw, $m ) ) {
             $addr = strtolower( $m[1] );
             // Extract onionname from URL path: ...onion/NAME or ...onion/NAME/
@@ -419,17 +420,34 @@ add_action( 'admin_init', function () {
             $addr = $raw;
             $feed_url = $raw;
         } elseif ( function_exists( 'onionpress_directory_lookup' ) ) {
-            // Treat as onionname — resolve to .onion via local registry
+            // Treat as onionname — resolve to .onion via local registry.
+            // If the name isn't registered, reject the input rather than
+            // saving the unresolved string as a fake "address" (that
+            // produced ghost follow entries with no actual onion target).
             $raw_lower = strtolower( $raw );
             $info = onionpress_directory_lookup( $raw_lower );
-            $addr = $info ? ( $info['onionaddress'] ?? '' ) : '';
-            if ( $addr ) {
+            if ( $info && ! empty( $info['onionaddress'] ) ) {
+                $addr = $info['onionaddress'];
                 $resolved_name = $raw_lower;
             } else {
-                $addr = $raw_lower;
+                add_action( 'admin_notices', function () use ( $raw_lower ) {
+                    echo '<div class="notice notice-error"><p>Onionname <code>'
+                        . esc_html( $raw_lower )
+                        . '</code> is not registered. Try a full <code>.onion</code> address or feed URL instead.</p></div>';
+                } );
+                return;
             }
-        } else {
-            $addr = strtolower( $raw );
+        }
+        // If we got here without an $addr, the input was unrecognisable
+        // (not a .onion, not a URL, no directory available) — bail
+        // rather than save garbage.
+        if ( $addr === '' ) {
+            add_action( 'admin_notices', function () use ( $raw ) {
+                echo '<div class="notice notice-error"><p>Could not interpret <code>'
+                    . esc_html( $raw )
+                    . '</code> as an onion address, feed URL, or registered onionname.</p></div>';
+            } );
+            return;
         }
         if ( $addr ) {
             if ( ! in_array( $addr, $following, true ) ) {


### PR DESCRIPTION
## Problem

The Follow form's input handler had a fallback path: when an input didn't match a \`.onion\` address or URL and didn't resolve to an onionname in the local registry, it stored the raw input string as the \"address\" — producing entries like \`foul-oyster\` in the Following list with no actual \`.onion\` target.

User-visible: typed an onionname that isn't registered, got back a Following entry with just the name and no address. That entry can't be probed, can't be fetched, and looks like a UI bug.

## Fix

Two cases tightened in \`onionpress-settings.php\`:

1. **Onionname lookup miss:** emit an admin notice (\"Onionname X is not registered\") and return without modifying the Following list.
2. **Unrecognisable input** (not a \`.onion\`, not a URL, no directory available): same — admin notice, no save.

## Test plan

- [x] PHP syntax check passes.
- [x] CI runs the existing tests.
- [ ] After merge, typing an unregistered name into the Follow box shows a clear admin notice instead of silently creating a ghost entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)