### PR TITLE
Bump version to 2.4.107

### DIFF
--- a/app/Info.plist
+++ b/app/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.106</string>
+	<string>2.4.107</string>
 	<key>CFBundleVersion</key>
 	<string>99</string>
 	<key>LSApplicationCategoryType</key>

--- a/src/menubar.py
+++ b/src/menubar.py
@@ -230,7 +230,7 @@ class OnionPressApp(rumps.App):
         self.icon = self.icon_stopped
 
         # Set version to placeholder (will be updated in background)
-        self.version = "2.4.106"
+        self.version = "2.4.107"
 
         # Set up environment variables (fast - no I/O)
         docker_config_dir = os.path.join(self.app_support, "docker-config")

--- a/src/onionpress/__init__.py
+++ b/src/onionpress/__init__.py
@@ -1,3 +1,3 @@
 """OnionPress — shared Python package for CLI and menubar."""
 
-__version__ = "2.4.106"
+__version__ = "2.4.107"


### PR DESCRIPTION
Bumps the three canonical version locations (`src/menubar.py`, `app/Info.plist`, `src/onionpress/__init__.py`) from 2.4.106 → 2.4.107 ahead of cutting the v2.4.107 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)