### PR TITLE
Bump version to 2.4.108; refresh image digests for the wp2shell fix

### DIFF
--- a/app/Info.plist
+++ b/app/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.107</string>
+	<string>2.4.108</string>
 	<key>CFBundleVersion</key>
 	<string>99</string>
 	<key>LSApplicationCategoryType</key>

--- a/app/Resources/docker/docker-compose.yml
+++ b/app/Resources/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   tor:
-    image: ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:e06286cbcbf6b34b1fe29636ffeea381c1aa96050c947e0d4ef7250f64993ea2
+    image: ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:fed4f5b44324064ce63bf05dbc6aeee26efe354ed3861abea8bf5082b1d29146
     container_name: onionpress-tor
     logging:
       driver: json-file
@@ -30,7 +30,7 @@ services:
       - "${ONIONPRESS_BIND_HOST:-127.0.0.1}:${ONIONPRESS_SOCKS_PORT:-9050}:9050"
 
   wordpress:
-    image: ghcr.io/brewsterkahle/onionpress-wordpress:latest@sha256:278582e9960344e8cf1d296ac6f7020413ad3e5a2eaed6b63603300f47e4c8bd
+    image: ghcr.io/brewsterkahle/onionpress-wordpress:latest@sha256:073e261e029867629f93483bad13bdb197dc267eb3bacd6e2ade561283f816b0
     container_name: onionpress-wordpress
     logging:
       driver: json-file
@@ -129,7 +129,7 @@ services:
     restart: unless-stopped
 
   onionheaven:
-    image: ${ONIONHEAVEN_IMAGE:-ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:e06286cbcbf6b34b1fe29636ffeea381c1aa96050c947e0d4ef7250f64993ea2}
+    image: ${ONIONHEAVEN_IMAGE:-ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:fed4f5b44324064ce63bf05dbc6aeee26efe354ed3861abea8bf5082b1d29146}
     container_name: onionheaven
     logging:
       driver: json-file

--- a/linux/onionpress
+++ b/linux/onionpress
@@ -667,8 +667,8 @@ update_images() {
     # with build/refresh-image-digests.sh at each release. mariadb stays
     # on :latest to receive upstream security patches automatically.
     local images=(
-        "ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:e06286cbcbf6b34b1fe29636ffeea381c1aa96050c947e0d4ef7250f64993ea2"
-        "ghcr.io/brewsterkahle/onionpress-wordpress:latest@sha256:278582e9960344e8cf1d296ac6f7020413ad3e5a2eaed6b63603300f47e4c8bd"
+        "ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:fed4f5b44324064ce63bf05dbc6aeee26efe354ed3861abea8bf5082b1d29146"
+        "ghcr.io/brewsterkahle/onionpress-wordpress:latest@sha256:073e261e029867629f93483bad13bdb197dc267eb3bacd6e2ade561283f816b0"
         "mariadb:latest"
     )
     local pulled=0

--- a/src/menubar.py
+++ b/src/menubar.py
@@ -230,7 +230,7 @@ class OnionPressApp(rumps.App):
         self.icon = self.icon_stopped
 
         # Set version to placeholder (will be updated in background)
-        self.version = "2.4.107"
+        self.version = "2.4.108"
 
         # Set up environment variables (fast - no I/O)
         docker_config_dir = os.path.join(self.app_support, "docker-config")

--- a/src/onionpress/__init__.py
+++ b/src/onionpress/__init__.py
@@ -1,3 +1,3 @@
 """OnionPress — shared Python package for CLI and menubar."""
 
-__version__ = "2.4.107"
+__version__ = "2.4.108"

--- a/src/onionpress/containers.py
+++ b/src/onionpress/containers.py
@@ -22,7 +22,7 @@ CORE_SERVICES = ["wordpress", "db", "onionheaven", "autoheal"]
 ALL_SERVICES = ["wordpress", "db", "tor", "onionheaven", "autoheal"]
 # Pinned to digest — must match docker-compose.yml and linux/onionpress.
 # Refresh all three together via build/refresh-image-digests.sh.
-ONIONHEAVEN_IMAGE = "ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:e06286cbcbf6b34b1fe29636ffeea381c1aa96050c947e0d4ef7250f64993ea2"
+ONIONHEAVEN_IMAGE = "ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:fed4f5b44324064ce63bf05dbc6aeee26efe354ed3861abea8bf5082b1d29146"
 
 
 @dataclass

--- a/src/onionpress/launcher_ops.py
+++ b/src/onionpress/launcher_ops.py
@@ -24,7 +24,7 @@ from typing import Optional
 
 # Pinned to digest — must match docker-compose.yml and linux/onionpress.
 # Refresh all three together via build/refresh-image-digests.sh.
-DEFAULT_TOR_IMAGE = "ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:e06286cbcbf6b34b1fe29636ffeea381c1aa96050c947e0d4ef7250f64993ea2"
+DEFAULT_TOR_IMAGE = "ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:fed4f5b44324064ce63bf05dbc6aeee26efe354ed3861abea8bf5082b1d29146"
 
 
 def _tor_browser_lock_paths() -> list:


### PR DESCRIPTION
Pins the images built from d413771b (workflow run 30680211476).

The new WordPress image ships **WordPress 7.0.2** — patched against wp2shell (CVE-2026-63030 + CVE-2026-60137) — and carries `onionpress-security-audit.sh`. So new installs land on a patched core directly, and existing installs get updated by the audit script on their next container start.

Verified in the built image before pinning:

```
WP version in image: 7.0.2
audit script: present+executable
multisite-init has new policy: 1
old constants gone: 0
entrypoint calls audit: 1
```

All four pin locations refreshed together via `build/refresh-image-digests.sh`: `docker-compose.yml`, `linux/onionpress`, `containers.py`, `launcher_ops.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)