### PR TITLE
security-audit: fix update check firing on every boot

### DIFF
--- a/app/Resources/docker/wordpress/onionpress-security-audit.sh
+++ b/app/Resources/docker/wordpress/onionpress-security-audit.sh
@@ -65,9 +65,16 @@ log "WordPress core version: $current"
 # --minor keeps us on the current major (7.0.x -> 7.0.2) which is where the
 # security backports land. A major jump unattended could break multisite or
 # the bundled mu-plugins.
-if $WP core check-update --minor --field=version >/dev/null 2>&1 \
-        && [ -n "$($WP core check-update --minor --field=version 2>/dev/null)" ]; then
-    target=$($WP core check-update --minor --field=version 2>/dev/null | head -1)
+#
+# Test with --format=json, which yields exactly "[]" when there is nothing
+# to do. Do NOT test `--field=version` for emptiness: when the install is
+# already current, wp-cli prints "Success: WordPress is at the latest
+# version." on stdout, so a -n test reads that sentence as a version number
+# and fires a pointless update on every single boot.
+pending=$($WP core check-update --minor --format=json 2>/dev/null | tr -d '[:space:]')
+if [ -n "$pending" ] && [ "$pending" != "[]" ]; then
+    target=$(printf '%s' "$pending" | grep -o '"version":"[^"]*"' | head -1 | cut -d'"' -f4)
+    [ -z "$target" ] && target="(unknown)"
     log "security update available: $current -> $target — applying now"
     if $WP core update --minor >/dev/null 2>&1; then
         # Multisite stores schema version per-network; core update alone


### PR DESCRIPTION
`wp core check-update --minor --field=version` does not print nothing when the install is already current — it prints `Success: WordPress is at the latest version.` on stdout. The `-n` test therefore read that sentence as a version number, logged this on every start:

```
[security-audit] security update available: 7.0.2 -> Success: WordPress is at the latest version. — applying now
[security-audit] core updated to 7.0.2 and DB migrated
```

and ran a redundant `wp core update --minor` each boot.

Harmless in outcome — the update is a no-op when current and checksums still verify — but it misleads exactly the person reading these logs during an incident, and it makes WordPress hit the update API on every boot, which is unwanted chatter for a tool whose users are trying not to generate any.

Now tests `--format=json`, which yields exactly `[]` when there's nothing to do, and pulls the target version from that same JSON.

Verified against a live container:
```
[security-audit] WordPress core version: 7.0.2
[security-audit] core is up to date
[security-audit] no indicators of compromise found
```

Found by recreating the container on the 2.4.108 image to confirm the entrypoint actually invokes the audit — it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)