### PR TITLE
Bump version to 2.4.109; refresh image digests for the audit fix

### DIFF
--- a/app/Info.plist
+++ b/app/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.108</string>
+	<string>2.4.109</string>
 	<key>CFBundleVersion</key>
 	<string>99</string>
 	<key>LSApplicationCategoryType</key>

--- a/app/Resources/docker/docker-compose.yml
+++ b/app/Resources/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   tor:
-    image: ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:fed4f5b44324064ce63bf05dbc6aeee26efe354ed3861abea8bf5082b1d29146
+    image: ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:ecab8ad6c9a196b308441f1eac787504d8c43fb6ad7638363edb14a41e784e2b
     container_name: onionpress-tor
     logging:
       driver: json-file
@@ -30,7 +30,7 @@ services:
       - "${ONIONPRESS_BIND_HOST:-127.0.0.1}:${ONIONPRESS_SOCKS_PORT:-9050}:9050"
 
   wordpress:
-    image: ghcr.io/brewsterkahle/onionpress-wordpress:latest@sha256:073e261e029867629f93483bad13bdb197dc267eb3bacd6e2ade561283f816b0
+    image: ghcr.io/brewsterkahle/onionpress-wordpress:latest@sha256:5056497e355667c6f440baf75721e189c7845921218468f566d34e20c39bc776
     container_name: onionpress-wordpress
     logging:
       driver: json-file
@@ -129,7 +129,7 @@ services:
     restart: unless-stopped
 
   onionheaven:
-    image: ${ONIONHEAVEN_IMAGE:-ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:fed4f5b44324064ce63bf05dbc6aeee26efe354ed3861abea8bf5082b1d29146}
+    image: ${ONIONHEAVEN_IMAGE:-ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:ecab8ad6c9a196b308441f1eac787504d8c43fb6ad7638363edb14a41e784e2b}
     container_name: onionheaven
     logging:
       driver: json-file

--- a/linux/onionpress
+++ b/linux/onionpress
@@ -667,8 +667,8 @@ update_images() {
     # with build/refresh-image-digests.sh at each release. mariadb stays
     # on :latest to receive upstream security patches automatically.
     local images=(
-        "ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:fed4f5b44324064ce63bf05dbc6aeee26efe354ed3861abea8bf5082b1d29146"
-        "ghcr.io/brewsterkahle/onionpress-wordpress:latest@sha256:073e261e029867629f93483bad13bdb197dc267eb3bacd6e2ade561283f816b0"
+        "ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:ecab8ad6c9a196b308441f1eac787504d8c43fb6ad7638363edb14a41e784e2b"
+        "ghcr.io/brewsterkahle/onionpress-wordpress:latest@sha256:5056497e355667c6f440baf75721e189c7845921218468f566d34e20c39bc776"
         "mariadb:latest"
     )
     local pulled=0

--- a/src/menubar.py
+++ b/src/menubar.py
@@ -230,7 +230,7 @@ class OnionPressApp(rumps.App):
         self.icon = self.icon_stopped
 
         # Set version to placeholder (will be updated in background)
-        self.version = "2.4.108"
+        self.version = "2.4.109"
 
         # Set up environment variables (fast - no I/O)
         docker_config_dir = os.path.join(self.app_support, "docker-config")

--- a/src/onionpress/__init__.py
+++ b/src/onionpress/__init__.py
@@ -1,3 +1,3 @@
 """OnionPress — shared Python package for CLI and menubar."""
 
-__version__ = "2.4.108"
+__version__ = "2.4.109"

--- a/src/onionpress/containers.py
+++ b/src/onionpress/containers.py
@@ -22,7 +22,7 @@ CORE_SERVICES = ["wordpress", "db", "onionheaven", "autoheal"]
 ALL_SERVICES = ["wordpress", "db", "tor", "onionheaven", "autoheal"]
 # Pinned to digest — must match docker-compose.yml and linux/onionpress.
 # Refresh all three together via build/refresh-image-digests.sh.
-ONIONHEAVEN_IMAGE = "ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:fed4f5b44324064ce63bf05dbc6aeee26efe354ed3861abea8bf5082b1d29146"
+ONIONHEAVEN_IMAGE = "ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:ecab8ad6c9a196b308441f1eac787504d8c43fb6ad7638363edb14a41e784e2b"
 
 
 @dataclass

--- a/src/onionpress/launcher_ops.py
+++ b/src/onionpress/launcher_ops.py
@@ -24,7 +24,7 @@ from typing import Optional
 
 # Pinned to digest — must match docker-compose.yml and linux/onionpress.
 # Refresh all three together via build/refresh-image-digests.sh.
-DEFAULT_TOR_IMAGE = "ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:fed4f5b44324064ce63bf05dbc6aeee26efe354ed3861abea8bf5082b1d29146"
+DEFAULT_TOR_IMAGE = "ghcr.io/brewsterkahle/onionpress-tor:latest@sha256:ecab8ad6c9a196b308441f1eac787504d8c43fb6ad7638363edb14a41e784e2b"
 
 
 def _tor_browser_lock_paths() -> list:


### PR DESCRIPTION
Pins images built from f6c91493, which carries the `security-audit` fix for the update check that misread wp-cli's "WordPress is at the latest version." success message as a version number and fired a redundant core update on every container start.

Validated against two different installs:

| install | WP version | audit result |
|---|---|---|
| this machine (multisite) | 7.0.2 | `core is up to date` / no IOCs |
| OnionHome | 6.9.5 | `core is up to date` / no IOCs |

The `--minor` policy correctly holds 6.9.5 on the 6.9.x line rather than jumping to 7.0.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)