### PR TITLE
Sanity check mission statement

### DIFF
--- a/.claude/commands/mission.md
+++ b/.claude/commands/mission.md
@@ -1,0 +1,26 @@
+# OnionPress Mission Review
+
+Review the current task or change through the lens of OnionPress's three core author commitments:
+
+## 1. Author Safety
+- Does this change preserve or improve anonymity? Nothing should leak the author's real IP, identity, or location.
+- Does it avoid creating new attack surfaces that could expose an author to retaliation, surveillance, or takedown?
+- When in doubt, favor the approach that gives authors more control and less exposure.
+
+## 2. Ease of Publishing
+- Authors are not sysadmins. Any new complexity must be invisible by default or clearly optional.
+- WordPress is the publishing surface by design — keep it central. Don't force authors to learn Tor internals, Docker, or CLI tooling to publish content.
+- Error messages should guide, not dump. If something fails, tell the author what to do next, not what went wrong internally.
+
+## 3. Content Durability
+- Published content should outlast the author's machine, their ISP, or a hostile takedown attempt.
+- Tor onion services provide resilience without DNS — no registrar can yank the domain. Preserve this property.
+- Internet Archive integration is a durability backstop — archived content survives even if the onion service goes offline. Treat archival as a first-class feature, not an afterthought.
+
+## Checklist
+Before finalizing any design or implementation decision, confirm:
+- [ ] Author anonymity is not weakened
+- [ ] A non-technical author could use this without reading docs
+- [ ] Content published through this path will still be reachable if the author's Mac is offline
+- [ ] The change works without DNS (onion address only is valid)
+- [ ] No new dependency on a centralized service that could be pressured to cut off access

--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,6 @@ onionheaven-stress-results/
 tests/onionheaven-stress-results/
 
 # Per-user Claude Code config (local permissions, hooks, etc.)
-.claude/
+# Commands are shared and travel with the repo; everything else stays local.
+.claude/*
+!.claude/commands/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,7 @@
 
 ## Meta
 - **This file (`CLAUDE.md`) is the project memory.** Store all new memories and notes here so they travel with the repo.
+- Run `/mission` at any point to evaluate a change against OnionPress's three author commitments: safety, ease of publishing, and content durability.
 
 ## Naming Rules (IMPORTANT)
 - The project is called **OnionPress** (one word, capital O and P). Never "Onion.Press", "onion.press", or "onion-press".


### PR DESCRIPTION
## Summary

A gentle first pass at ensuring work on this project adhere to  the principles underlying this project

## Changes

* adds a `/mission` command` for use within an LLM development hardness (e.g. claude code) that verifies the currently outstanding work adheres to the  mission of the project
* carves out an exception in `.gitignore`. Previously all of `.claude` was ignored, but now the contents of `.claude/commands` 

## Related issue

Inspired by  issue #231  