### PR TITLE
Bug fixes: launcher lifecycle, auto-login open redirect, onionname redirects, truthful status

### DIFF
--- a/app/MacOS/onionpress
+++ b/app/MacOS/onionpress
@@ -487,7 +487,7 @@ detect_container_runtime() {
         if [ -f "$COLIMA_HOME/.initialized" ]; then
             if "$BIN_DIR/colima" status >/dev/null 2>&1; then
                 # Check if configured VM memory differs from running VM
-                _cfg_mem=1
+                _cfg_mem=2
                 if [ -f "$DATA_DIR/config" ]; then
                     _tmp_mem=$(grep "^VM_MEMORY=" "$DATA_DIR/config" | cut -d= -f2)
                     [ -n "$_tmp_mem" ] && _cfg_mem="$_tmp_mem"
@@ -539,7 +539,7 @@ detect_container_runtime() {
                 log "Starting bundled Colima..."
 
                 # Read VM memory/CPU from config so restarts honour changes
-                _restart_mem=1
+                _restart_mem=2
                 _restart_cpu=2
                 if [ -f "$DATA_DIR/config" ]; then
                     _cfg_mem=$(grep "^VM_MEMORY=" "$DATA_DIR/config" | cut -d= -f2)
@@ -998,8 +998,8 @@ configure_cache_enabler() {
 install_docker() {
     log "Container runtime initialization required"
 
-    # Read VM memory from config (default: 1 GB)
-    VM_MEMORY=1
+    # Read VM memory from config (default: 2 GB — the stack idles at ~840 MB)
+    VM_MEMORY=2
     VM_CPU=2
     if [ -f "$DATA_DIR/config" ]; then
         config_mem=$(grep "^VM_MEMORY=" "$DATA_DIR/config" | cut -d= -f2)

--- a/app/MacOS/onionpress
+++ b/app/MacOS/onionpress
@@ -1979,8 +1979,15 @@ main() {
                 fi
             fi
             echo $$ > "$PIDFILE"
-            # On exit: clean PID file and kill our background children
-            trap 'rm -f "$PIDFILE"; kill $(jobs -p) 2>/dev/null' EXIT INT TERM HUP
+            # On exit: clean PID file and kill our background children.
+            # The `|| true` is load-bearing: under `set -e`, a failing command
+            # inside the EXIT trap becomes the SCRIPT's exit status. `kill`
+            # fails when the jobs table is empty or only holds already-finished
+            # jobs — so a fully successful `start` exited 1 whenever its
+            # background children happened to finish first (race), which any
+            # caller that checks the exit code (a managing app's stack installer) read
+            # as a start failure.
+            trap 'rm -f "$PIDFILE"; kill $(jobs -p) 2>/dev/null || true' EXIT INT TERM HUP
 
             # Note: orphaned background processes from previous launches may exist
             # but are harmless (sleeping poll loops). The exit trap kills our own

--- a/app/Resources/config-template.txt
+++ b/app/Resources/config-template.txt
@@ -72,16 +72,20 @@ LAUNCH_ON_LOGIN=yes
 PREVENT_SLEEP=normal
 
 # Virtual Machine Memory (GB)
-# Default: 1 (1 GB RAM for the container VM)
+# Default: 2 (2 GB RAM for the container VM)
 #
 # The Linux VM that runs WordPress, Tor, and MariaDB containers.
-# 1 GB is sufficient for normal use. OnionHeaven instances auto-increase
-# to 5 GB on first detection. Increase manually if you run many plugins
-# or experience out-of-memory issues.
+# The stack idles at ~840 MB (tor 250, onionheaven 286, wordpress 154,
+# mariadb 141, autoheal 8), so the old 1 GB default left ~115 MB free
+# before anything was published — and a large static-site upload then got
+# the kernel OOM-killer instead of an error. 2 GB leaves ~1.1 GB, headroom
+# for large uploads and for WordPress itself.
+# OnionHeaven instances auto-increase to 5 GB on first detection.
+# Increase manually if you run many plugins or publish very large sites.
 #
 # Requires restart to take effect.
 #
-VM_MEMORY=1
+VM_MEMORY=2
 
 # Cloudflare Tunnel (Clearnet Access)
 # Expose your WordPress site on the regular internet with HTTPS via Cloudflare Tunnel.

--- a/app/Resources/plugins/onionpress-auto-login.php
+++ b/app/Resources/plugins/onionpress-auto-login.php
@@ -56,6 +56,31 @@ add_action( 'init', function () {
     // intermediate from caching the cookies and serving them to the next
     // visitor.
     nocache_headers();
-    wp_redirect( remove_query_arg( 'op_login' ) );
+
+    // Land the caller wherever it asked (e.g. the static homepage, which
+    // never runs PHP and so could never carry the token itself — the
+    // menubar app instead points here, at wp-login.php, then redirects
+    // back). Only a same-request relative path is accepted: WordPress's
+    // core redirect validator checks the *configured* home_url host,
+    // which — same as the cookie domain above — can differ from the
+    // actual request host (.onion vs localhost), so it can't be used to
+    // validate this. Sanitize BEFORE validating, not after: wp_redirect()
+    // calls wp_sanitize_redirect() internally right before it sends the
+    // Location header, and that strips characters outside a fixed
+    // allowlist — validating the raw value first lets a stripped
+    // character sitting between two slashes (e.g. "/\evil.com" or
+    // "/%09/evil.com") collapse into "//evil.com" after sanitizing,
+    // which browsers resolve as protocol-relative. The regex below
+    // additionally rejects a leading backslash right after the slash,
+    // since some browsers normalize "/\host" the same way.
+    $redirect_to = remove_query_arg( 'op_login' );
+    if ( ! empty( $_GET['redirect_to'] ) ) {
+        $requested = wp_sanitize_redirect( wp_unslash( $_GET['redirect_to'] ) );
+        if ( preg_match( '#^/($|[^/\\\\])#', $requested ) ) {
+            $redirect_to = $requested;
+        }
+    }
+
+    wp_redirect( $redirect_to );
     exit;
 } );

--- a/app/Resources/plugins/onionpress-directory.php
+++ b/app/Resources/plugins/onionpress-directory.php
@@ -73,6 +73,41 @@ function onionpress_directory_request_is_clearnet() {
 }
 
 /**
+ * Path segments that are WordPress's, never an onionname.
+ *
+ * The first segment of any URL is now treated as a candidate name (deep
+ * paths are carried through to the target), so the handful of segments
+ * that unambiguously belong to this site are excluded before we ask the
+ * registry about them.
+ */
+function onionpress_directory_is_reserved_segment( $segment ) {
+    $reserved = array(
+        'wp-admin', 'wp-json', 'wp-content', 'wp-includes', 'wp-login',
+        'feed', 'follow', 'xmlrpc.php',
+    );
+    return in_array( strtolower( (string) $segment ), $reserved, true );
+}
+
+/**
+ * The URL a claimed name resolves to: the target's onion ROOT, plus
+ * whatever path followed the name, plus the original query string.
+ *
+ * A name is registry state, not site state. The site is served at the onion
+ * root and has no /<name>/ path of its own, so appending the name — which
+ * this did until 2026-08-17 — 404s every claimed name. Carrying the
+ * remainder through is the other half: a name is only worth having if you
+ * can hand someone a link to a page, not just to a homepage.
+ */
+function onionpress_directory_target_url( $addr, $suffix = '' ) {
+    $url = 'http://' . $addr . '/' . ltrim( (string) $suffix, '/' );
+    $query = (string) ( $_SERVER['QUERY_STRING'] ?? '' );
+    if ( $query !== '' ) {
+        $url .= '?' . $query;
+    }
+    return $url;
+}
+
+/**
  * Read this instance's own .onion address from the shared volume the
  * launcher populates. Returns lower-case .onion or null.
  */
@@ -200,7 +235,7 @@ function onionpress_directory_handle_follow_by_name( $name ) {
  * OTHER .onion, 302 to that site. If the target is this instance, fall
  * through so WP multisite serves the local blog.
  */
-function onionpress_directory_handle_name_lookup( $name ) {
+function onionpress_directory_handle_name_lookup( $name, $suffix = '' ) {
     // Cheap client-side filter — avoids a curl hop for obviously-invalid
     // segments. Mirrors the server's validate_name rules.
     if (
@@ -239,7 +274,7 @@ function onionpress_directory_handle_name_lookup( $name ) {
         $addr_h  = esc_html( $info['onionaddress'] );
         $addr_a  = esc_attr( $info['onionaddress'] );
         $onion_h = esc_html(
-            'http://' . $info['onionaddress'] . '/' . $info['onionname'] . '/'
+            onionpress_directory_target_url( $info['onionaddress'], $suffix )
         );
         echo '<!doctype html><meta charset="utf-8"><title>@' . $name_h . ' — OnionPress</title>';
         echo '<meta name="robots" content="noindex, nofollow">';
@@ -253,13 +288,14 @@ function onionpress_directory_handle_name_lookup( $name ) {
         exit;
     }
 
-    // Bare-NAME redirect on the onion side: point at the target's
-    // /<name>/ path, which onionpress-user-path.php rewrites to the
-    // user's author archive on the target's WordPress. That gives us a
-    // stable, share-worthy URL (op2abc.onion/brewsterkahle) even when the
-    // target has just one blog.
+    // Onion-side redirect: point at the target's ROOT, carrying any path
+    // that followed the name. This used to append /<name>/ on the theory
+    // that onionpress-user-path.php would rewrite it to an author archive,
+    // but that rewriter only runs on a network-root multisite install
+    // (onionpress-user-path.php gates on blog_id 1), so on a self-hosted
+    // node serving one site at the root every claimed name 404'd.
     wp_redirect(
-        'http://' . $info['onionaddress'] . '/' . $info['onionname'] . '/',
+        onionpress_directory_target_url( $info['onionaddress'], $suffix ),
         302
     );
     exit;
@@ -295,9 +331,23 @@ add_action( 'parse_request', function ( $wp ) {
         return;
     }
 
-    // /NAME — single path segment. Skip if the URL has more than one segment
-    // (posts, categories, etc.) or looks like a reserved path.
-    if ( $path !== '' && strpos( $path, '/' ) === false ) {
-        onionpress_directory_handle_name_lookup( $path );
+    // /NAME[/REST] — the first segment is the candidate onionname and
+    // everything after it is carried through to the target unchanged, so
+    // /alice/posts/hello lands on /posts/hello rather than 404ing. Deep
+    // paths used to be skipped entirely, which meant a name could only ever
+    // link to a homepage.
+    //
+    // An unregistered first segment (every ordinary WordPress URL) falls
+    // through untouched: lookup returns null. The pre-filter in
+    // handle_name_lookup keeps that from costing a registry hop for most of
+    // them, and this dispatcher only runs on the OnionHome hosts, where the
+    // registry is a local container call rather than a trip over Tor.
+    if ( $path !== '' ) {
+        $parts  = explode( '/', $path, 2 );
+        $segment = $parts[0];
+        $suffix  = isset( $parts[1] ) ? $parts[1] : '';
+        if ( ! onionpress_directory_is_reserved_segment( $segment ) ) {
+            onionpress_directory_handle_name_lookup( $segment, $suffix );
+        }
     }
 } );

--- a/app/Resources/plugins/onionpress-directory.php
+++ b/app/Resources/plugins/onionpress-directory.php
@@ -43,6 +43,36 @@ function onionpress_directory_is_onionhome_host( $host ) {
 }
 
 /**
+ * The host this request arrived on: lower-cased, port stripped.
+ *
+ * Extracted because the same three lines were hand-rolled in two places and
+ * only one of them kept the variable it assigned. The other read an
+ * undefined $own, so its clearnet check was constantly false and every
+ * clearnet visitor fell through to a redirect at a raw .onion URL their
+ * browser cannot open. One definition means the two callers cannot drift
+ * apart again.
+ */
+function onionpress_directory_request_host() {
+    $host = strtolower( (string) ( $_SERVER['HTTP_HOST'] ?? '' ) );
+    if ( strpos( $host, ':' ) !== false ) {
+        $host = substr( $host, 0, strpos( $host, ':' ) );
+    }
+    return $host;
+}
+
+/**
+ * True when this request came in over the clearnet bridge (onionpress.org
+ * via the Cloudflare tunnel) rather than over Tor.
+ */
+function onionpress_directory_request_is_clearnet() {
+    $host = onionpress_directory_request_host();
+    return (
+        $host === ONIONPRESS_CLEARNET_HOST
+        || $host === 'www.' . ONIONPRESS_CLEARNET_HOST
+    );
+}
+
+/**
  * Read this instance's own .onion address from the shared volume the
  * launcher populates. Returns lower-case .onion or null.
  */
@@ -136,12 +166,7 @@ function onionpress_directory_handle_follow_by_name( $name ) {
         exit;
     }
 
-    $own = strtolower( (string) ( $_SERVER['HTTP_HOST'] ?? '' ) );
-    if ( strpos( $own, ':' ) !== false ) {
-        $own = substr( $own, 0, strpos( $own, ':' ) );
-    }
-    $is_clearnet = ( $own === ONIONPRESS_CLEARNET_HOST
-                     || $own === 'www.' . ONIONPRESS_CLEARNET_HOST );
+    $is_clearnet = onionpress_directory_request_is_clearnet();
 
     status_header( 200 );
     header( 'Content-Type: text/html; charset=utf-8' );
@@ -206,7 +231,7 @@ function onionpress_directory_handle_name_lookup( $name ) {
     // onionpress.org we don't ship them to a raw .onion URL in their
     // clearnet browser (which would just error). Surface a simple page
     // pointing at Tor Browser instead. Indexers explicitly blocked.
-    if ( $own === ONIONPRESS_CLEARNET_HOST || $own === 'www.' . ONIONPRESS_CLEARNET_HOST ) {
+    if ( onionpress_directory_request_is_clearnet() ) {
         status_header( 200 );
         header( 'X-Robots-Tag: noindex, nofollow' );
         header( 'Content-Type: text/html; charset=utf-8' );

--- a/app/Resources/scripts/install_plugin.sh
+++ b/app/Resources/scripts/install_plugin.sh
@@ -40,9 +40,22 @@ fi
 # onionheaven first: onionpress-tor is also publishing the user's onion
 # service, so bulk fetches belong on the other daemon. Never fall back to a
 # direct connection — no Tor means no download.
+#
+# --speed-limit/--speed-time is what makes the fallback worth having. A Tor
+# circuit can go silent without closing: the SOCKS handshake is local and
+# instant, so curl holds a live connection with nothing coming down it, and
+# --max-time alone cannot tell that apart from a genuinely slow download. On
+# 2026-08-22 that cost five minutes of a first-run install — onionheaven
+# accepted the Cache Enabler request, delivered 0 bytes for the full 300s, and
+# only then did onionpress-tor fetch the same file in two seconds. Aborting
+# below 1 KB/s for 30s catches the stall while leaving a slow-but-moving
+# download alone; measured first-byte through either proxy is ~3s, so 30s is
+# roughly 10x headroom. --max-time stays as the outer bound for a download
+# that crawls the whole way.
 downloaded=0
 for proxy in onionheaven onionpress-tor; do
     if docker exec "$CONTAINER" curl -sSL -f --max-time 300 \
+            --speed-limit 1024 --speed-time 30 \
             --socks5-hostname "${proxy}:9050" \
             -o "$REMOTE_ZIP" "$PLUGIN_URL" 2>&1; then
         downloaded=1

--- a/linux/onionpress-service.py
+++ b/linux/onionpress-service.py
@@ -208,6 +208,14 @@ def write_status(
 
     bootstrap_pct = health_result.bootstrap_pct if health_result else 0
 
+    # External reachability: HealthResult.tor_externally_reachable
+    # is itself None until Check 5 actually runs (full_check gates it on
+    # tor_internally_ready + onion_address) — mirror it straight through
+    # rather than re-deriving the gate here, so this can never fall out of
+    # sync with what actually decides "did we run the check".
+    onion_reachable = health_result.tor_externally_reachable if health_result else None
+    onion_http_code = health_result.external_http_code if health_result else None
+
     # Map ServiceState → status.json "state"
     state_str = {
         ServiceState.AVAILABLE: "running",
@@ -271,6 +279,8 @@ def write_status(
         "onion_address": onion_address,
         "uptime_seconds": uptime,
         "bootstrap_pct": bootstrap_pct,
+        "onion_reachable": onion_reachable,
+        "onion_http_code": onion_http_code,
         "containers": containers,
         "wayback_queue_count": wayback_queue,
         "updated_at": now,

--- a/linux/onionpress-service.py
+++ b/linux/onionpress-service.py
@@ -57,7 +57,7 @@ try:
     from onionpress.docker import Docker
     from onionpress.platform import resolve_paths, OS, detect_os
     from onionpress.config import (
-        ensure_config, ensure_secrets, read_value, detect_port_offset,
+        ensure_config, ensure_secrets, read_value, resolve_port_offset,
     )
     from onionpress import launcher_ops, system_metrics
     from onionpress.power import SystemdInhibitor
@@ -109,7 +109,7 @@ def _make_manager(docker: Docker) -> ContainerManager:
     # resolve_paths() leaves docker_dir="" when there's no app bundle.
     # On Linux the docker configs live under INSTALL_DIR.
     paths = dataclasses.replace(paths, docker_dir=DOCKER_DIR)
-    port_cfg = detect_port_offset()
+    port_cfg = resolve_port_offset()
     return ContainerManager(docker, paths, port_cfg, log_func=log)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,13 @@
 name = "onionpress-dev"
 version = "0"
 requires-python = ">=3.10"
+
+[tool.pytest.ini_options]
+# Put src/ on the import path so `from onionpress import ...` resolves.
+# Nothing else does: the package is never pip-installed for the tests, and
+# there is no conftest.py to fix it up. Without this, any test that imports
+# the package dies at COLLECTION with ModuleNotFoundError, which reads as a
+# broken checkout rather than a missing path — and the suites that shell out
+# to wp-cli instead of importing never notice, so the gap stays hidden until
+# someone runs the other half from a clean shell.
+pythonpath = ["src"]

--- a/src/menubar.py
+++ b/src/menubar.py
@@ -452,6 +452,7 @@ class OnionPressApp(rumps.App):
         self._reachability_stats = ReachabilityStats()
         self._last_probe_code = ""
         self._last_probe_ms = 0
+        self._last_reachability = (None, None)  # tri-state (reachable, http_code); None = never checked
         self._last_snapshot_ts = time.time()
         self._snapshot_interval_seconds = 12 * 3600
 
@@ -1329,6 +1330,16 @@ class OnionPressApp(rumps.App):
         self._tor_internally_ready = False
         self._last_probe_code = ""
         self._last_probe_ms = 0
+        # External reachability is tri-state, read by
+        # write_status_to_volume() from a DIFFERENT thread than this one.
+        # Stored as a single (reachable, http_code) tuple — one attribute,
+        # one store/load — rather than two separate attributes, so a
+        # concurrent reader can never observe a torn combination (e.g. a
+        # fresh http_code paired with a stale reachable from the previous
+        # cycle). None until Check 5 actually runs: a hostname/bootstrap/
+        # internal failure means we never asked the question, not that the
+        # answer was "no".
+        self._last_reachability = (None, None)
         if not self.onion_address or self.onion_address in ["Starting...", "Not running", "Generating address..."]:
             self._last_probe_code = "no_address"
             return False
@@ -1372,6 +1383,7 @@ class OnionPressApp(rumps.App):
             reachable, http_code = self._health_checker.check_external_reachability(self.onion_address)
             self._last_probe_ms = int((time.monotonic() - _probe_start) * 1000)
             self._last_probe_code = http_code or ""
+            self._last_reachability = (reachable, http_code or None)
             if not reachable:
                 if log_result:
                     if http_code == "takeover":
@@ -1682,6 +1694,11 @@ class OnionPressApp(rumps.App):
                     if self.is_ready:
                         self.log("Going offline — no internet connection")
                     self.is_ready = False
+                    # check_tor_reachability() isn't called on this
+                    # path, so the reachability tuple would otherwise keep
+                    # whatever it was before the internet dropped — reporting
+                    # a stale "reachable" verdict while genuinely offline.
+                    self._last_reachability = (None, None)
                     # Track yellow/starting state
                     if self._yellow_since is None:
                         self._yellow_since = time.time()
@@ -1992,6 +2009,11 @@ class OnionPressApp(rumps.App):
                 if not self.onion_address or self.onion_address in ["Starting...", "Generating address..."]:
                     self.onion_address = "Not running"
                 self.is_ready = False
+                # Containers aren't all up, so nothing will call
+                # check_tor_reachability() again until they are — clear the
+                # last verdict rather than let a stale "reachable: true"
+                # from before the stop keep being reported.
+                self._last_reachability = (None, None)
                 # Don't reset auto_opened_browser — browser is already open
                 self._wp_installed = None  # Reset for next start
                 self._wp_not_installed_count = 0
@@ -4777,6 +4799,13 @@ License: AGPL v3"""
             if self.is_ready:
                 bootstrap_pct = 100
 
+            # Surface the same tri-state reachability the linux service
+            # writes — None until Check 5 has actually run; only an
+            # explicit False means confirmed unreachable. Read as
+            # one tuple (see check_tor_reachability) so a concurrent update
+            # from the status-loop thread can't be observed half-applied.
+            onion_reachable, onion_http_code = getattr(self, '_last_reachability', (None, None))
+
             # OnionHeaven stats
             oh_server_active = getattr(self, 'is_onionheaven', False)
             oh_stats = {'server_active': oh_server_active, 'client_registered': False,
@@ -4849,6 +4878,8 @@ License: AGPL v3"""
                 'tor_impl': self._read_config_value("TOR_IMPL", "tor"),
                 'uptime_seconds': uptime_seconds,
                 'bootstrap_pct': bootstrap_pct,
+                'onion_reachable': onion_reachable,
+                'onion_http_code': onion_http_code,
                 'containers': containers,
                 'updated_at': datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                 'platform': 'macos',

--- a/src/menubar.py
+++ b/src/menubar.py
@@ -4140,7 +4140,7 @@ class OnionPressApp(rumps.App):
                 # Check if onionheaven mode was restored
                 onionheaven_addr = "oheavenfhbohpdjijmxo3xgvvuo6eleyhhorbompoycle6x5eajlp7qd.onion"
                 if restored_addr == onionheaven_addr:
-                    cur_mem = self._read_config_value("VM_MEMORY", "1")
+                    cur_mem = self._read_config_value("VM_MEMORY", "2")
                     try:
                         cur_mem_int = int(cur_mem)
                     except ValueError:

--- a/src/menubar.py
+++ b/src/menubar.py
@@ -277,8 +277,12 @@ class OnionPressApp(rumps.App):
         except (OSError, ValueError):
             pass  # corrupt or unreadable — proceed to normal detection
 
-        # Detect port offset for multi-user support
-        _port_config = op_config.detect_port_offset()
+        # Detect port offset for multi-user support. resolve_port_offset()
+        # reads our own running container's published port first (if a
+        # stack is already up) and only allocates via bind-probing when
+        # nothing is running yet — see its docstring for why the bind
+        # probe alone can't answer "what port is our own stack on".
+        _port_config = op_config.resolve_port_offset()
         self.wp_port = _port_config.wp_port
         self.socks_port = _port_config.socks_port
         self.proxy_port = _port_config.proxy_port
@@ -2749,6 +2753,32 @@ class OnionPressApp(rumps.App):
         thread = threading.Thread(target=generator, daemon=True)
         thread.start()
 
+    def _resync_ports(self):
+        """Re-read our own container's published port after start/restart.
+
+        __init__ resolves the offset once; a stop/start can bring the
+        stack up on a different offset than that snapshot (e.g. another
+        process — the `onionpress` CLI, a stale env var — raced us and
+        picked its own). Comparing against what Docker actually published
+        keeps self.wp_port (and everything derived from it: local_url,
+        onion_proxy globals, ONIONPRESS_*_PORT env vars) truthful instead
+        of silently mis-addressed for the rest of the session.
+        """
+        running_port = launcher_ops.get_running_wp_port()
+        if running_port is None or running_port == self.wp_port:
+            return
+        offset = running_port - 8080
+        self.log(f"Port resync: was {self.wp_port}, running stack is on {running_port}")
+        self.wp_port = running_port
+        self.socks_port = 9050 + offset
+        self.proxy_port = 9077 + offset
+        os.environ["ONIONPRESS_PORT_OFFSET"] = str(offset)
+        os.environ["ONIONPRESS_WP_PORT"] = str(self.wp_port)
+        os.environ["ONIONPRESS_SOCKS_PORT"] = str(self.socks_port)
+        os.environ["ONIONPRESS_PROXY_PORT"] = str(self.proxy_port)
+        onion_proxy.PROXY_PORT = self.proxy_port
+        onion_proxy.PHP_PROXY_PORT = self.wp_port
+
     @property
     def local_url(self):
         """The local URL for accessing WordPress."""
@@ -3036,6 +3066,7 @@ class OnionPressApp(rumps.App):
             # Start the service normally
             self.update_splash_status("Starting your site...")
             subprocess.run([self.launcher_script, "start"])
+            self._resync_ports()
 
             # Poll until WordPress is responding (replaces fixed sleep)
             self.update_splash_status("Starting your site...")
@@ -3711,6 +3742,7 @@ class OnionPressApp(rumps.App):
 
             # Run restart command
             subprocess.run([self.launcher_script, "restart"])
+            self._resync_ports()
 
             # Poll until WordPress is responding (replaces fixed sleep)
             max_wait = 60

--- a/src/onionpress/config.py
+++ b/src/onionpress/config.py
@@ -15,6 +15,7 @@ import socket
 import subprocess
 from dataclasses import dataclass
 
+from . import launcher_ops
 from .platform import OnionPressPaths
 
 # Default config values matching config-template.txt
@@ -369,3 +370,32 @@ def detect_port_offset() -> PortConfig:
         socks_port=9050 + offset,
         proxy_port=9077 + offset,
     )
+
+
+def resolve_port_offset() -> PortConfig:
+    """Return the port offset our own stack is actually using.
+
+    detect_port_offset() allocates: it binds candidate ports and returns
+    the first free one, which is correct before anything is running. Once
+    our WordPress container is up, its ports are bound (by the container
+    itself), so a fresh bind test just reports "in use" without saying
+    which port that is — including the mundane case where the caller is
+    asking about the very stack it's part of.
+
+    Read the running container's published port first (authoritative —
+    Docker already made this mapping) and only fall back to allocation
+    when nothing is running yet. Callers that need the multi-user
+    allocation behavior with no risk of misreading a foreign container
+    (e.g. a first-launch check before anything of ours exists) should call
+    detect_port_offset() directly instead.
+    """
+    running_port = launcher_ops.get_running_wp_port()
+    if running_port is not None and running_port >= 8080:
+        offset = running_port - 8080
+        return PortConfig(
+            offset=offset,
+            wp_port=running_port,
+            socks_port=9050 + offset,
+            proxy_port=9077 + offset,
+        )
+    return detect_port_offset()

--- a/src/onionpress/health.py
+++ b/src/onionpress/health.py
@@ -57,16 +57,21 @@ class HealthResult:
     wp_healthy: bool = False
     tor_bootstrapped: bool = False
     tor_internally_ready: bool = False  # Checks 1-4 passed
-    tor_externally_reachable: bool = False  # Check 5 passed (dual-probe)
+    # Check 5 (dual-probe) is tri-state: None until it actually runs — the
+    # gate below is the ONLY place that assigns it. Do not default this to
+    # False: an unrun check and a check that came back negative must stay
+    # distinguishable all the way out to status.json (see write_status()
+    # in linux/onionpress-service.py and menubar.py's write_status_to_volume).
+    tor_externally_reachable: Optional[bool] = None
     onion_address: str = ""
     bootstrap_pct: int = 0
-    external_http_code: str = ""  # HTTP status from external reachability check
+    external_http_code: Optional[str] = None  # HTTP status from external reachability check
     errors: list[str] = field(default_factory=list)
 
     @property
     def ready(self) -> bool:
         """Service is fully operational."""
-        return self.wp_healthy and self.tor_externally_reachable
+        return self.wp_healthy and self.tor_externally_reachable is True
 
 
 @dataclass

--- a/src/onionpress/launcher_ops.py
+++ b/src/onionpress/launcher_ops.py
@@ -311,6 +311,42 @@ def signal_watchdog(docker, container: str, sig: str) -> bool:
     return bool(getattr(result, "ok", False))
 
 
+def get_running_wp_port(container: str = "onionpress-wordpress") -> Optional[int]:
+    """Read the host port our own WordPress container actually published.
+
+    `detect_port_offset()` binds candidate ports to find one that's free —
+    correct for allocation at first launch, wrong as a runtime lookup: once
+    a stack is up, its ports are bound (by the stack itself), so the bind
+    test always fails and reports "in use", concluding nothing about which
+    port was actually chosen. Reading `docker port` instead asks the one
+    source that's authoritative once a stack exists — the mapping Docker
+    already made — for both the "still on our own port" case and the "came
+    up on a different offset than last time" case (stop/start races where
+    the old offset's forwards are still bound when the new ones come up).
+
+    Returns None if the container isn't running or isn't ours to read
+    (multi-user machines: this only ever inspects a container name, never
+    another user's — Docker containers are per-user via the docker socket
+    each user's Colima VM exposes, so there is no cross-user leakage here).
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "port", container, "80"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    # Expected output: "0.0.0.0:8080" or "127.0.0.1:8080" (one line per
+    # bound address; take the first).
+    first_line = result.stdout.strip().splitlines()[0] if result.stdout.strip() else ""
+    if ":" not in first_line:
+        return None
+    port_str = first_line.rsplit(":", 1)[-1]
+    return int(port_str) if port_str.isdigit() else None
+
+
 def get_admin_password(data_dir: str) -> Optional[str]:
     """Read the auto-generated WP admin password (`~/.onionpress/wp-admin-password`).
 

--- a/tests/test-auto-login-redirect.php
+++ b/tests/test-auto-login-redirect.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * test-auto-login-redirect.php — regression coverage for the redirect_to
+ * sanitize-before-validate ordering in onionpress-auto-login.php.
+ *
+ * The validation lives inline in the plugin's `init` closure, so — same
+ * technique as tests/test-tor-bridge-config.sh — the block is extracted from
+ * the shipped source and evaluated here, keeping the test honest against the
+ * real code instead of a copy that can drift. The few WordPress functions the
+ * block touches are stubbed below; wp_sanitize_redirect() is a faithful
+ * minimal port of core's character-allowlist strip, because the whole bug is
+ * about what that strip does to a value validated too early.
+ *
+ * Runs standalone: `php tests/test-auto-login-redirect.php`.
+ * Exit status is 0 only if every assertion passes.
+ */
+
+$pass = 0;
+$fail = 0;
+function ok( $label ) {
+    global $pass;
+    $pass++;
+    printf( "PASS  %s\n", $label );
+}
+function bad( $label, $detail = '' ) {
+    global $fail;
+    $fail++;
+    printf( "FAIL  %s%s\n", $label, $detail !== '' ? " ($detail)" : '' );
+}
+function assert_eq( $label, $expected, $actual ) {
+    if ( $expected === $actual ) {
+        ok( $label );
+    } else {
+        bad( $label, 'expected ' . var_export( $expected, true ) . ', got ' . var_export( $actual, true ) );
+    }
+}
+
+// --- WordPress stubs ---------------------------------------------------
+
+// Minimal faithful port of core wp_sanitize_redirect(): strip everything
+// outside the allowlist, then remove encoded CR/LF. This is the strip that
+// collapses "/<tab>/evil.com" into "//evil.com" — the reason validation must
+// run on the sanitized value, never the raw one.
+function wp_sanitize_redirect( $location ) {
+    $location = str_replace( ' ', '%20', $location );
+    $location = preg_replace( '|[^a-z0-9-~+_.?#=&;,/:%!*\[\]()@]|i', '', $location );
+    return str_ireplace( array( '%0d', '%0a' ), '', $location );
+}
+
+// In WordPress $_GET arrives slashed and wp_unslash() undoes that; the test
+// feeds the already-decoded raw value directly, so identity is faithful here.
+function wp_unslash( $value ) {
+    return $value;
+}
+
+// The closure's fallback when redirect_to is absent or rejected: the current
+// URL minus the token. A sentinel keeps accept/reject outcomes unambiguous.
+define( 'OP_FALLBACK', '/fallback-current-url' );
+function remove_query_arg( $arg ) {
+    return OP_FALLBACK;
+}
+
+// --- Extract the validation block from the shipped plugin --------------
+
+$plugin = __DIR__ . '/../app/Resources/plugins/onionpress-auto-login.php';
+$src    = file_get_contents( $plugin );
+if ( $src === false
+    || ! preg_match( '/\$redirect_to = remove_query_arg.*?(?=\n\s*wp_redirect)/s', $src, $m ) ) {
+    echo "FAIL  could not extract the redirect_to validation block from $plugin\n";
+    exit( 1 );
+}
+eval( "function op_pick_redirect() {\n" . $m[0] . "\nreturn \$redirect_to;\n}" );
+
+function pick( $redirect_to ) {
+    $_GET = array( 'redirect_to' => $redirect_to );
+    return op_pick_redirect();
+}
+
+// --- Cases --------------------------------------------------------------
+
+// Ordinary relative path: accepted as-is.
+assert_eq( 'accepts /dashboard', '/dashboard', pick( '/dashboard' ) );
+
+// Tab-smuggled protocol-relative bypass (the URL form is /%09/evil.com; PHP
+// hands the plugin the decoded "/\t/evil.com"). Raw, the second character is
+// a tab, so validate-before-sanitize passed it — and wp_redirect()'s internal
+// sanitize then collapsed it to "//evil.com", an open redirect. Sanitizing
+// first collapses it BEFORE the regex looks, so it must fall back.
+assert_eq( 'rejects /%09/evil.com (tab-smuggled //)', OP_FALLBACK, pick( "/\t/evil.com" ) );
+
+// Backslash form: browsers normalize "/\evil.com" like "//evil.com". After
+// the sanitize strips the backslash it survives only as the harmless local
+// path "/evil.com" — what matters is that no backslash and no leading "//"
+// can ever reach the Location header.
+$out = pick( '/\\evil.com' );
+if ( strpos( $out, '\\' ) === false && substr( $out, 0, 2 ) !== '//' ) {
+    ok( 'rejects /\\evil.com as an external target (got ' . var_export( $out, true ) . ')' );
+} else {
+    bad( 'rejects /\\evil.com as an external target', 'got ' . var_export( $out, true ) );
+}
+// And the regex itself rejects a surviving leading backslash outright
+// (defense in depth for any sanitize that lets one through).
+assert_eq( 'regex refuses a leading backslash after /',
+    0, preg_match( '#^/($|[^/\\\\])#', '/\\evil.com' ) );
+
+printf( "\n%d passed, %d failed\n", $pass, $fail );
+exit( $fail === 0 ? 0 : 1 );

--- a/tests/test_install_invariants.py
+++ b/tests/test_install_invariants.py
@@ -197,6 +197,46 @@ class TestMakefilePrecheckUsesCorrectPath(unittest.TestCase):
         )
 
 
+class TestPluginDownloadAbortsOnAStalledCircuit(unittest.TestCase):
+    """install_plugin.sh tries onionheaven first and onionpress-tor second.
+    That fallback only helps if the first attempt gives up promptly.
+
+    On 2026-08-22 it did not. A Tor circuit went silent without closing —
+    the SOCKS handshake is local and instant, so curl sat on a live
+    connection receiving nothing. `--max-time 300` was the only bound, and
+    a silent circuit is indistinguishable from a slow download until that
+    deadline expires, so a first-run install showed five minutes of
+    "Starting OnionPress" before onionpress-tor fetched the same file in
+    two seconds.
+
+    The guard is a low-speed abort, not a shorter deadline: cutting
+    --max-time would also kill a slow download that is making progress.
+    """
+
+    def test_download_has_a_low_speed_abort_on_every_proxy_attempt(self):
+        sh = _read("app/Resources/scripts/install_plugin.sh")
+        self.assertRegex(
+            sh,
+            r'--speed-limit\s+\d+',
+            "The plugin download must abort a stalled transfer via "
+            "--speed-limit; --max-time alone cannot detect a silent circuit.",
+        )
+        self.assertRegex(
+            sh,
+            r'--speed-time\s+\d+',
+            "--speed-limit does nothing without --speed-time.",
+        )
+
+    def test_the_outer_deadline_survives(self):
+        sh = _read("app/Resources/scripts/install_plugin.sh")
+        self.assertRegex(
+            sh,
+            r'--max-time\s+\d+',
+            "--max-time is the outer bound for a download that crawls the "
+            "whole way and stays just above the low-speed floor.",
+        )
+
+
 class TestSubsiteGetsOnionPressTheme(unittest.TestCase):
     """RECURRING regression: after `wp site create` creates the primary
     subsite at /<onionname>/, the new subsite gets WordPress's default

--- a/tests/test_onionname_redirect.py
+++ b/tests/test_onionname_redirect.py
@@ -102,6 +102,110 @@ class TestClearnetHostDetection(unittest.TestCase):
         self.assertFalse(self._is_clearnet("")["clearnet"])
 
 
+@unittest.skipUnless(PHP, "php not installed")
+class TestNameResolvesToTheOnionRoot(unittest.TestCase):
+    """Where the redirect points.
+
+    The target was built as <onion>/<name>/ on the theory that
+    onionpress-user-path.php would rewrite that into an author archive. That
+    rewriter only runs on a network-root multisite install, so on a
+    self-hosted node serving one site at the onion root every claimed name
+    404'd. A name is registry state, not site state: it resolves to the
+    site's root, and any path after it belongs to the target.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="onionpress-target-test-")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.addr = (
+            "op2ykvbdwzg75f3pifywmwdjue5utsg4yi4j72wadpk32varfcdk6uad.onion"
+        )
+
+    def _target(self, suffix="", query=""):
+        harness = textwrap.dedent(f"""\
+            <?php
+            define('ABSPATH', __DIR__);
+            function add_action(...$args) {{}}
+            $_SERVER['HTTP_HOST'] = 'onionpress.org';
+            $_SERVER['QUERY_STRING'] = {json.dumps(query)};
+            require {json.dumps(PLUGIN)};
+            echo onionpress_directory_target_url(
+                {json.dumps(self.addr)}, {json.dumps(suffix)}
+            );
+        """)
+        path = os.path.join(self.tmp, "target.php")
+        with open(path, "w") as f:
+            f.write(harness)
+        proc = subprocess.run(
+            [PHP, "-d", "error_reporting=E_ALL", "-d", "display_errors=stderr",
+             path],
+            capture_output=True, text=True, timeout=30,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertNotIn("Warning", proc.stderr, proc.stderr)
+        return proc.stdout
+
+    def test_a_bare_name_resolves_to_the_site_root(self):
+        self.assertEqual(self._target(), f"http://{self.addr}/")
+
+    def test_the_name_is_not_appended_as_a_path(self):
+        """The bug itself, stated as an assertion."""
+        self.assertNotIn("william-blake", self._target())
+
+    def test_a_deep_path_is_carried_through(self):
+        """A name is only worth having if you can link to a page."""
+        self.assertEqual(
+            self._target("posts/hello"),
+            f"http://{self.addr}/posts/hello",
+        )
+
+    def test_a_query_string_survives(self):
+        self.assertEqual(
+            self._target("posts/hello", "utm_source=x"),
+            f"http://{self.addr}/posts/hello?utm_source=x",
+        )
+
+    def test_a_leading_slash_on_the_suffix_does_not_double_up(self):
+        self.assertEqual(
+            self._target("/posts/hello"), f"http://{self.addr}/posts/hello"
+        )
+
+
+class TestReservedSegmentsAreNotNames(unittest.TestCase):
+    """Treating the first segment as a candidate name means WordPress's own
+    paths would otherwise be looked up in the registry."""
+
+    def setUp(self):
+        self.src = _read("app/Resources/plugins/onionpress-directory.php")
+
+    def test_wordpress_paths_are_excluded(self):
+        for segment in ("wp-admin", "wp-json", "wp-login", "feed"):
+            self.assertIn(
+                f"'{segment}'", self.src,
+                f"{segment} must be reserved, not treated as an onionname.",
+            )
+
+    def test_the_dispatcher_consults_the_reserved_list(self):
+        dispatch = self.src.index("add_action( 'parse_request'")
+        self.assertIn(
+            "onionpress_directory_is_reserved_segment", self.src[dispatch:],
+            "The dispatcher must skip reserved segments before looking a "
+            "name up.",
+        )
+
+    def test_deep_paths_reach_the_name_handler(self):
+        """The old dispatcher skipped anything containing a slash, so deep
+        paths got no redirect at all."""
+        dispatch = self.src.index("add_action( 'parse_request'")
+        body = self.src[dispatch:]
+        self.assertNotIn(
+            "strpos( $path, '/' ) === false", body,
+            "The single-segment restriction is what stopped deep paths from "
+            "resolving; it must not come back.",
+        )
+        self.assertIn("explode( '/', $path, 2 )", body)
+
+
 class TestClearnetGuardIsWiredUp(unittest.TestCase):
     """The call sites. The helper being right is worth nothing if the
     name-lookup path does not consult it before redirecting."""

--- a/tests/test_onionname_redirect.py
+++ b/tests/test_onionname_redirect.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""The onionname directory's clearnet guard.
+
+`https://onionpress.org/<name>` is the URL a publisher shows the user as
+their onion name, so it is the product's human-readable identity. It was
+302ing clearnet browsers straight at a raw .onion URL, which no clearnet
+browser can open — the plugin has a dedicated branch to serve a "you need
+Tor Browser" page instead, and that branch was dead code: it tested `$own`,
+a variable assigned only in a *different* function, so the comparison was
+always false and control fell through to the redirect.
+
+An undefined variable in PHP is a warning, not an error, which is exactly
+why this survived: the page still rendered, the redirect still fired, and
+nothing in the suite looked at the host. These tests run the real helper
+under the real PHP, and pin the two call sites that must route through it.
+
+php is preinstalled on ubuntu-latest, so this runs in the existing Python CI
+job — no separate PHP job to collide with the receiver work in flight.
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+PLUGIN = os.path.join(
+    PROJECT_ROOT, "app", "Resources", "plugins", "onionpress-directory.php"
+)
+
+PHP = shutil.which("php")
+
+
+def _read(rel_path):
+    with open(os.path.join(PROJECT_ROOT, rel_path), "r", encoding="utf-8") as f:
+        return f.read()
+
+
+@unittest.skipUnless(PHP, "php not installed")
+class TestClearnetHostDetection(unittest.TestCase):
+    """The helper itself, under real PHP."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="onionpress-directory-test-")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+    def _is_clearnet(self, host):
+        """Load the real plugin with a minimal WordPress stub and ask it."""
+        harness = textwrap.dedent(f"""\
+            <?php
+            // The plugin is a mu-plugin: it refuses to load outside WP and
+            // registers one hook at the bottom. Both are cheap to satisfy.
+            define('ABSPATH', __DIR__);
+            function add_action(...$args) {{}}
+
+            $_SERVER['HTTP_HOST'] = {json.dumps(host)};
+            require {json.dumps(PLUGIN)};
+
+            echo json_encode([
+                'host' => onionpress_directory_request_host(),
+                'clearnet' => onionpress_directory_request_is_clearnet(),
+            ]);
+        """)
+        path = os.path.join(self.tmp, "harness.php")
+        with open(path, "w") as f:
+            f.write(harness)
+
+        proc = subprocess.run(
+            [PHP, "-d", "error_reporting=E_ALL", "-d", "display_errors=stderr",
+             path],
+            capture_output=True, text=True, timeout=30,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        # An undefined variable is only a warning; surface it as a failure so
+        # this class of bug cannot come back quietly.
+        self.assertNotIn("Warning", proc.stderr, proc.stderr)
+        self.assertNotIn("Undefined", proc.stderr, proc.stderr)
+        return json.loads(proc.stdout)
+
+    def test_the_clearnet_bridge_is_recognised(self):
+        self.assertTrue(self._is_clearnet("onionpress.org")["clearnet"])
+
+    def test_the_www_form_is_recognised(self):
+        self.assertTrue(self._is_clearnet("www.onionpress.org")["clearnet"])
+
+    def test_case_and_port_do_not_defeat_it(self):
+        result = self._is_clearnet("OnionPress.org:8443")
+        self.assertEqual(result["host"], "onionpress.org")
+        self.assertTrue(result["clearnet"])
+
+    def test_an_onion_host_is_not_clearnet(self):
+        """On the onion side the redirect is the correct behaviour — the
+        visitor is already in Tor Browser."""
+        onion = "op2ykvbdwzg75f3pifywmwdjue5utsg4yi4j72wadpk32varfcdk6uad.onion"
+        self.assertFalse(self._is_clearnet(onion)["clearnet"])
+
+    def test_a_missing_host_is_not_clearnet(self):
+        self.assertFalse(self._is_clearnet("")["clearnet"])
+
+
+class TestClearnetGuardIsWiredUp(unittest.TestCase):
+    """The call sites. The helper being right is worth nothing if the
+    name-lookup path does not consult it before redirecting."""
+
+    def setUp(self):
+        self.src = _read("app/Resources/plugins/onionpress-directory.php")
+
+    def test_no_undefined_own_variable_remains(self):
+        """The original bug, stated directly: $own is assigned in
+        handle_follow_by_name and was read in handle_name_lookup."""
+        reads = [
+            line for line in self.src.splitlines()
+            if re.search(r"\$own\b", line) and not line.strip().startswith("*")
+        ]
+        self.assertEqual(
+            reads, [],
+            "$own is back. Use onionpress_directory_request_is_clearnet() "
+            "rather than re-deriving the host in a second place.",
+        )
+
+    def test_both_clearnet_checks_use_the_shared_helper(self):
+        self.assertEqual(
+            self.src.count("onionpress_directory_request_is_clearnet()"), 3,
+            "Expected one definition and two call sites (the follow page and "
+            "the name lookup).",
+        )
+
+    def test_the_guard_precedes_the_onion_redirect(self):
+        """A clearnet visitor must be answered with the Tor Browser page, not
+        handed a .onion URL their browser cannot open."""
+        lookup = self.src.index("function onionpress_directory_handle_name_lookup")
+        body = self.src[lookup:]
+        guard = body.index("onionpress_directory_request_is_clearnet()")
+        redirect = body.index("wp_redirect(")
+        self.assertLess(
+            guard, redirect,
+            "The clearnet guard must run before wp_redirect(), or clearnet "
+            "visitors are redirected to a raw .onion URL.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_onionpress_config.py
+++ b/tests/test_onionpress_config.py
@@ -1,11 +1,13 @@
 """Tests for src/onionpress/config.py."""
 
 import os
+import socket
 import stat
 import sys
 import tempfile
 import shutil
 import unittest
+from unittest import mock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
@@ -14,7 +16,7 @@ from onionpress.config import (
     read_config, read_value, write_value, write_config,
     validate_address_prefix,
     Secrets, load_secrets, ensure_secrets,
-    PortConfig, detect_port_offset,
+    PortConfig, detect_port_offset, resolve_port_offset,
     ensure_config,
     SAFE_CONFIG_KEYS, redact_config,
 )
@@ -304,6 +306,59 @@ class TestPortDetection(unittest.TestCase):
         pc = PortConfig(offset=10000, wp_port=18080, socks_port=19050, proxy_port=19077)
         self.assertEqual(pc.offset, 10000)
         self.assertEqual(pc.wp_port, 18080)
+
+    def test_foreign_holder_still_bumps_offset(self):
+        """detect_port_offset() is a bind-based allocator: it can't tell
+        "someone else holds this port" from "we do" — it only knows
+        "taken". That's correct for the multi-user path (another macOS
+        account legitimately holds 8080) and must keep bumping to +10000
+        in that case; resolve_port_offset() (tested below) is what adds
+        the "is it actually us" distinction on top."""
+        real_socket_cls = socket.socket
+
+        class FakeSocket(real_socket_cls):
+            def bind(self, addr):
+                if addr[1] == 8080:
+                    raise OSError("address in use (simulated foreign holder)")
+                return super().bind(addr)
+
+        with mock.patch("onionpress.config.socket.socket", FakeSocket):
+            pc = detect_port_offset()
+        self.assertEqual(pc.offset, 10000)
+        self.assertEqual(pc.wp_port, 18080)
+
+
+class TestResolvePortOffset(unittest.TestCase):
+    """resolve_port_offset() is the runtime lookup detect_port_offset()
+    can't be: it reads our own running container's published port first
+    (authoritative) and only falls back to bind-probe allocation when
+    nothing of ours is up yet.
+    """
+
+    def test_reads_running_stack_port_without_bumping(self):
+        with mock.patch("onionpress.config.launcher_ops.get_running_wp_port",
+                         return_value=8080):
+            pc = resolve_port_offset()
+        self.assertEqual(pc, PortConfig(offset=0, wp_port=8080, socks_port=9050, proxy_port=9077))
+
+    def test_reads_running_stack_on_nonzero_offset(self):
+        # A stack that came up on a non-default offset (multi-user, or a
+        # prior restart that landed elsewhere) must be followed, not
+        # silently mis-addressed for the rest of the session.
+        with mock.patch("onionpress.config.launcher_ops.get_running_wp_port",
+                         return_value=18080):
+            pc = resolve_port_offset()
+        self.assertEqual(pc, PortConfig(offset=10000, wp_port=18080, socks_port=19050, proxy_port=19077))
+
+    def test_falls_back_to_detect_when_nothing_running(self):
+        sentinel = PortConfig(offset=20000, wp_port=28080, socks_port=29050, proxy_port=29077)
+        with mock.patch("onionpress.config.launcher_ops.get_running_wp_port",
+                         return_value=None), \
+             mock.patch("onionpress.config.detect_port_offset",
+                         return_value=sentinel) as m:
+            pc = resolve_port_offset()
+        m.assert_called_once()
+        self.assertEqual(pc, sentinel)
 
 
 class TestDefaults(unittest.TestCase):

--- a/tests/test_onionpress_health.py
+++ b/tests/test_onionpress_health.py
@@ -46,6 +46,20 @@ class TestHealthResult(unittest.TestCase):
         self.assertFalse(hr.ready)
         self.assertEqual(hr.errors, [])
 
+    def test_unknown_reachability_defaults_to_none_not_false(self):
+        # Reachability is tri-state: a HealthResult that never ran Check 5
+        # must be distinguishable from one that ran it and got a negative
+        # answer — status.json (and any consumer of onion_reachable) treats
+        # None as "unknown", never as "confirmed unreachable".
+        hr = HealthResult()
+        self.assertIsNone(hr.tor_externally_reachable)
+        self.assertIsNone(hr.external_http_code)
+        self.assertFalse(hr.ready)  # None must not satisfy `ready`
+
+    def test_not_ready_when_reachability_unknown(self):
+        hr = HealthResult(wp_healthy=True, tor_externally_reachable=None)
+        self.assertFalse(hr.ready)
+
 
 class TestCheckWordpressLocal(unittest.TestCase):
     def test_healthy(self):
@@ -383,6 +397,33 @@ class TestFullCheck(unittest.TestCase):
         hr = hc.full_check()
         self.assertFalse(hr.ready)
         self.assertFalse(hr.tor_internally_ready)
+        # Check 5 never ran (gated on tor_internally_ready) — the
+        # regression this guards is write_status() reading this as a
+        # confirmed-unreachable `false` instead of "never asked".
+        self.assertIsNone(hr.tor_externally_reachable)
+        self.assertIsNone(hr.external_http_code)
+
+    def test_missing_onion_address_skips_check_5_leaves_reachability_unknown(self):
+        # Checks 1-4 can all pass with no onion_address yet (e.g. hostname
+        # file present but check_tor_hostname returned "" for some other
+        # reason) — full_check's Check 5 gate requires BOTH
+        # tor_internally_ready and onion_address, so this exercises the
+        # other half of that gate.
+        docker = mock.Mock()
+        docker.exec.side_effect = [
+            _ok("<html>"),   # check_wordpress_local
+            _fail(),         # check_tor_bootstrap control-port probe
+            _ok(""),         # check_tor_hostname → empty address
+            _ok(),           # check_internal_connectivity
+        ]
+        docker.run.return_value = _ok("Bootstrapped 100% (done)")
+        hc = HealthChecker(docker)
+        hr = hc.full_check()
+        self.assertTrue(hr.tor_internally_ready)
+        self.assertEqual(hr.onion_address, "")
+        self.assertIsNone(hr.tor_externally_reachable)
+        self.assertIsNone(hr.external_http_code)
+        self.assertFalse(hr.ready)
 
 
 class TestHealthMonitorEvaluate(unittest.TestCase):


### PR DESCRIPTION
Part 1 of the series in #277. Independent bug fixes.

- `start` re-probed for a free port instead of resolving the running stack's. After a restart it could point WordPress at a port nothing was listening on.
- A successful `start` could exit 1. The EXIT trap's cleanup result became the script's exit code, so callers that check exit status saw failure on success.
- Auto-login `redirect_to` was an open redirect. The value is now run through `wp_sanitize_redirect()` *before* validation (matching what `wp_redirect()` does to it anyway) and validated as a single-slash-anchored relative path. Includes bypass tests for the sanitize-then-collapse trick (`/\evil.com` → `//evil.com`).
- The clearnet onionname page was dead code. Every clearnet visitor to a claimed name got a 302 to the `.onion` they usually cannot open; the page now resolves to the site root, and deep paths carry through.
- A stalled WordPress plugin download hung first-run installs for 300 s. The installer fetches plugins over Tor with a proxy fallback, but a dead circuit held the connection silently until curl's 300 s deadline; a stall detector now aborts after 30 s below 1 KB/s, so the fallback gets its turn.
- Reachability was collapsed to a boolean. It is tri-state at its source (reachable / unreachable / unknown) and status.json now says which, so "we don't know yet" no longer reads as "down". This changes status.json's shape, so anything parsing the old boolean needs to follow.

**Others**
Not strictly bug fixes, but seems like good setup:
- Default VM memory raised to 2 GB. 1 GB OOMs the stack under an ordinary WordPress + MariaDB load.
- `pyproject.toml` puts `src/` on pytest's path so the suite runs from a clean checkout.

