### PR TITLE
Serve a published static site ahead of WordPress

### DIFF
--- a/app/MacOS/onionpress
+++ b/app/MacOS/onionpress
@@ -1405,7 +1405,8 @@ chown www-data:www-data /var/www/html/.htaccess' >> "$LOG_FILE" 2>&1 && \
     bundled_python -m onionpress.cli deactivate-wp-statistics
     bundled_python -m onionpress.cli provision-post-install \
         --themes-dir "$RESOURCES_DIR/themes" \
-        --plugins-dir "$RESOURCES_DIR/plugins"
+        --plugins-dir "$RESOURCES_DIR/plugins" \
+        --apache-conf-dir "$DOCKER_DIR/wordpress"
 
     # install-from-backup: clean up staging + marker only after a successful
     # import + provisioning, so an interrupted run re-imports on the next start.
@@ -2230,7 +2231,8 @@ main() {
             # Python for now.
             bundled_python -m onionpress.cli provision-post-install \
                 --themes-dir "$RESOURCES_DIR/themes" \
-                --plugins-dir "$RESOURCES_DIR/plugins"
+                --plugins-dir "$RESOURCES_DIR/plugins" \
+                --apache-conf-dir "$DOCKER_DIR/wordpress"
             ;;
 
         setup)

--- a/app/Resources/docker/wordpress/Dockerfile
+++ b/app/Resources/docker/wordpress/Dockerfile
@@ -6,6 +6,12 @@ RUN curl -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh
 
 # Enable mod_remoteip for PROXY protocol support and add port 81 listener
 # Raise PHP upload limits for large Creations files (videos, HEIC, etc.)
+#
+# This COPY only takes effect for whoever BUILDS this image. Installs that
+# pull the published image by digest get the same file injected at runtime
+# instead, as an overriding conf.d overlay — see
+# src/onionpress/multisite.py:install_uploads_ini. The two paths read this
+# one source file, so they cannot disagree.
 COPY onionpress-uploads.ini /usr/local/etc/php/conf.d/
 
 RUN a2enmod remoteip rewrite headers
@@ -13,6 +19,13 @@ COPY onionpress-proxy-protocol.conf /etc/apache2/conf-available/
 COPY onionpress-xmlrpc-block.conf /etc/apache2/conf-available/
 COPY onionpress-log-format.conf /etc/apache2/conf-available/
 RUN a2enconf onionpress-proxy-protocol onionpress-xmlrpc-block onionpress-log-format
+
+# NOTE: onionpress-static-site.conf (static-first serving of published
+# site generations) is deliberately NOT baked in here. It is injected at
+# provision time via `docker cp` + `a2enconf` — see
+# src/onionpress/multisite.py:install_static_site_conf. This keeps the
+# published WordPress image (which docker-compose.yml pulls by digest,
+# never rebuilds) reusable unchanged: no image rebuild, no registry push.
 
 # Multisite init script — runs on every container start to ensure
 # multisite is configured (safe to re-run, checks if already done)

--- a/app/Resources/docker/wordpress/onionpress-static-site.conf
+++ b/app/Resources/docker/wordpress/onionpress-static-site.conf
@@ -1,0 +1,66 @@
+# Serve the current site generation's static files ahead of WordPress.
+#
+# The onionpress-static-receiver mu-plugin extracts an uploaded static site to
+# /var/www/html/site-generations/<id>/ and points the symlink
+# /var/www/html/site/current at the live one. This config makes Apache serve
+# those files directly, falling through to WordPress for everything else.
+#
+# Scope: this is a conf-enabled file, so the <Directory> block applies at
+# server scope to BOTH vhosts that share DocumentRoot /var/www/html -- the
+# default *:80 vhost (localhost / host port map) and the *:81 PROXY-protocol
+# vhost the tor container forwards onion traffic to.
+#
+# Why InheritDownBefore: /var/www/html/.htaccess (WordPress multisite, shipped
+# with AllowOverride All) has its own RewriteEngine, and per-directory
+# (.htaccess) rewrite rules normally REPLACE the rules from a <Directory>
+# block for the same directory. RewriteOptions InheritDownBefore pushes the
+# rules below down into that .htaccess scope and evaluates them BEFORE
+# WordPress's own rules, so a static hit wins and any non-static request falls
+# through to WordPress unchanged.
+#
+# Why [END] (not [L]): [END] stops rewrite processing completely, so the
+# rewritten /site/current/... path is served directly with no second
+# per-directory pass -- no rewrite loop, and no dependence on whether
+# %{REQUEST_URI} is refreshed between passes. On a static hit WordPress's
+# rules never run.
+<Directory /var/www/html>
+    RewriteEngine On
+    RewriteOptions InheritDownBefore
+
+    # Site root ("/") -> the current generation's index.html, when present.
+    # Gated on the exact request URI so it only ever fires for the site root,
+    # never for a subdirectory root in an inherited per-directory context.
+    RewriteCond %{REQUEST_URI} =/
+    RewriteCond %{DOCUMENT_ROOT}/site/current/index.html -f
+    RewriteRule ^ /site/current/index.html [END]
+
+    # Any other request that maps to a real file in the current generation is
+    # served statically. The ^/wp- exclusion also spares /wp-json, so the REST
+    # API -- including the static receiver's own /wp-json/onionpress/v1/* routes
+    # -- is never shadowed. Directories fall through (-f matches files only),
+    # leaving WordPress subsites reachable.
+    RewriteCond %{REQUEST_URI} !^/wp- [NC]
+    RewriteCond %{DOCUMENT_ROOT}/site/current%{REQUEST_URI} -f
+    RewriteRule ^ /site/current%{REQUEST_URI} [END]
+
+    # Pretty URLs. A published page is a DIRECTORY containing index.html
+    # (/about/index.html), which is the shape of essentially every static
+    # generator, so the -f rule above never matches one and the whole site
+    # except "/" fell through to WordPress -- which then answered with its own
+    # 404/dashboard for every link.
+    #
+    # Still gated on the file existing in the CURRENT generation, so the
+    # fall-through the rule above deliberately preserves is intact: a path the
+    # generation does not contain is untouched and WordPress subsites stay
+    # reachable. Two forms because %{REQUEST_URI} keeps its trailing slash,
+    # and "/foo//index.html" is not the same path.
+    RewriteCond %{REQUEST_URI} !^/wp- [NC]
+    RewriteCond %{REQUEST_URI} /$
+    RewriteCond %{DOCUMENT_ROOT}/site/current%{REQUEST_URI}index.html -f
+    RewriteRule ^ /site/current%{REQUEST_URI}index.html [END]
+
+    RewriteCond %{REQUEST_URI} !^/wp- [NC]
+    RewriteCond %{REQUEST_URI} !/$
+    RewriteCond %{DOCUMENT_ROOT}/site/current%{REQUEST_URI}/index.html -f
+    RewriteRule ^ /site/current%{REQUEST_URI}/index.html [END]
+</Directory>

--- a/app/Resources/docker/wordpress/onionpress-uploads.ini
+++ b/app/Resources/docker/wordpress/onionpress-uploads.ini
@@ -3,3 +3,7 @@ upload_max_filesize = 2G
 post_max_size = 2G
 max_execution_time = 300
 max_input_time = 300
+
+; Deliberately no memory_limit raise: large uploads arrive as multipart,
+; which PHP (rfc1867.c) streams to upload_tmp_dir at constant memory, so
+; upload_max_filesize/post_max_size above are the bounds that matter.

--- a/linux/onionpress
+++ b/linux/onionpress
@@ -1263,7 +1263,8 @@ start_containers() {
     # /var/lib/onionpress and wp-content/uploads.
     op_py provision-post-install \
         --themes-dir "$THEMES_DIR" \
-        --plugins-dir "$PLUGINS_DIR"
+        --plugins-dir "$PLUGINS_DIR" \
+        --apache-conf-dir "$DOCKER_DIR/wordpress"
 
 }
 
@@ -2352,7 +2353,8 @@ main() {
                 # installed, run it again to complete those steps.
                 op_py provision-post-install \
                     --themes-dir "$THEMES_DIR" \
-                    --plugins-dir "$PLUGINS_DIR" >> "$LOG_FILE" 2>&1 || true
+                    --plugins-dir "$PLUGINS_DIR" \
+                    --apache-conf-dir "$DOCKER_DIR/wordpress" >> "$LOG_FILE" 2>&1 || true
                 # Fetch archive.org S3 keys now that Tor is up and WP is
                 # installed — same timing as the Mac setup flow.
                 op_py ensure-archive-s3-keys >> "$LOG_FILE" 2>&1 &
@@ -2398,7 +2400,8 @@ sys.exit(0 if provision_interactive() else 1)
             # enforced inside the module — see its docstring for why.
             op_py provision-post-install \
                 --themes-dir "$THEMES_DIR" \
-                --plugins-dir "$PLUGINS_DIR"
+                --plugins-dir "$PLUGINS_DIR" \
+                --apache-conf-dir "$DOCKER_DIR/wordpress"
             ;;
 
         import-key)

--- a/src/onionpress/cli.py
+++ b/src/onionpress/cli.py
@@ -580,6 +580,11 @@ def main(argv: list[str] = None) -> int:
     p_ppi.add_argument(
         "--plugins-dir", required=True,
         help="Source directory containing mu-plugins, sunrise.php, icons")
+    p_ppi.add_argument(
+        "--apache-conf-dir",
+        help="Source directory containing onionpress-static-site.conf, "
+             "injected at runtime for static-first serving "
+             "(optional; skipped when omitted)")
 
     # Individual post-start provisioning steps. These are the helpers
     # start_containers used to inline as bash function calls; the bash
@@ -594,6 +599,24 @@ def main(argv: list[str] = None) -> int:
                    help="Remove WP-Statistics if present (clearnet leak)")
     sub.add_parser("ensure-archive-s3-keys",
                    help="Fetch shared archive.org S3 keys for Wayback archiving")
+
+    p_essc = sub.add_parser(
+        "ensure-static-site-conf",
+        help="Restore the static-first Apache conf if a container recreate "
+             "dropped it (cheap no-op when already present)",
+    )
+    p_essc.add_argument(
+        "--apache-conf-dir", required=True,
+        help="Source directory containing onionpress-static-site.conf")
+
+    p_eui = sub.add_parser(
+        "ensure-uploads-ini",
+        help="Restore the PHP limits overlay if a container recreate "
+             "dropped it (cheap no-op when already present)",
+    )
+    p_eui.add_argument(
+        "--conf-dir", required=True,
+        help="Source directory containing onionpress-uploads.ini")
 
     p_scrub = sub.add_parser(
         "scrub",
@@ -653,8 +676,29 @@ def main(argv: list[str] = None) -> int:
         return multisite.provision_post_install(
             themes_dir=args.themes_dir,
             plugins_dir=args.plugins_dir,
+            conf_dir=args.apache_conf_dir,
             log_func=print,
         )
+    elif args.command == "ensure-static-site-conf":
+        from . import multisite
+        # Deliberately always 0: this runs on the launcher's fast
+        # already-running path, where a missing container or a docker
+        # hiccup must not turn a healthy `start` into a reported failure.
+        multisite.ensure_static_site_conf(
+            conf_dir=args.apache_conf_dir,
+            log_func=print,
+        )
+        return 0
+    elif args.command == "ensure-uploads-ini":
+        from . import multisite
+        # Deliberately always 0, for the same reason as
+        # ensure-static-site-conf above: this runs on the launcher's fast
+        # already-running path.
+        multisite.ensure_uploads_ini(
+            conf_dir=args.conf_dir,
+            log_func=print,
+        )
+        return 0
     elif args.command == "configure-ia-plugin":
         from . import multisite
         return 0 if multisite.configure_ia_plugin(log_func=print) else 1

--- a/src/onionpress/multisite.py
+++ b/src/onionpress/multisite.py
@@ -51,6 +51,12 @@ MU_PLUGIN_ASSETS = (
     "onionpress-avatar-default.png",
 )
 
+# Where install_uploads_ini drops the PHP limits overlay. The `zz-` prefix
+# is load-bearing: PHP reads conf.d in alphabetical order and the last value
+# wins, so this sorts after the image's own onionpress-uploads.ini and
+# overrides it without overwriting it.
+UPLOADS_INI_PATH = "/usr/local/etc/php/conf.d/zz-onionpress-uploads.ini"
+
 # Multisite constants written to wp-config.php in ensure_multisite. The
 # values are wp-cli `--raw` literals (already-quoted strings stay quoted).
 MULTISITE_CONSTANTS = (
@@ -297,6 +303,291 @@ def install_multisite_domain_map(
             log(f"WARNING: Failed to copy {asset}")
 
     return True
+
+
+def install_static_site_conf(
+    *,
+    conf_dir: str,
+    docker_bin: str = "docker",
+    log_func: Optional[Callable[[str], None]] = None,
+) -> bool:
+    """Inject the Apache static-first conf into the running WordPress
+    container at provision time (the runtime equivalent of the Dockerfile
+    COPY + a2enconf we removed).
+
+    Why runtime, not baked-in: docker-compose.yml pulls the published
+    WordPress image by digest — it is never built locally. Baking
+    onionpress-static-site.conf into that image would force us to rebuild
+    + host a fork image. Copying it in the same way the mu-plugins are
+    (docker cp into the live container) reuses the published image
+    unchanged. Mind the
+    asymmetry with the mu-plugins, though: those land in /var/www/html,
+    which is a Docker volume and so persists, whereas /etc/apache2 is
+    container rootfs. This conf survives a restart but NOT a container
+    recreate, and the provisioning path that calls this does not run when
+    the launcher's `start` short-circuits on an already-running stack.
+    `ensure_static_site_conf` closes that gap — see its docstring.
+
+    `conf_dir` is the on-disk directory holding onionpress-static-site.conf
+    (Mac: `$RESOURCES_DIR/docker/wordpress`; Linux: `$INSTALL_DIR/docker/
+    wordpress`). Best-effort: a missing file or a not-yet-running container
+    logs a warning and returns False without aborting the provision run.
+    """
+    log = log_func or _noop_log
+    src = os.path.join(conf_dir, "onionpress-static-site.conf")
+    if not os.path.isfile(src):
+        log(f"WARNING: static-site Apache conf not found at {src} — "
+            "static-site serving not enabled")
+        return False
+
+    cp = _docker_cp(
+        src,
+        "onionpress-wordpress:/etc/apache2/conf-available/"
+        "onionpress-static-site.conf",
+        docker_bin=docker_bin,
+    )
+    if cp.returncode != 0:
+        log(f"WARNING: Failed to copy static-site Apache conf: "
+            f"{cp.stderr.strip()[:200]}")
+        return False
+
+    # Enable mod_rewrite (the conf's InheritDownBefore rules need it),
+    # enable the conf, then gracefully reload Apache so it takes effect
+    # without dropping in-flight requests. a2enmod/a2enconf are idempotent
+    # (no-op + exit 0 when already enabled), so this is safe every start.
+    r = _exec_sh(
+        "a2enmod rewrite && a2enconf onionpress-static-site && "
+        "apache2ctl graceful",
+        docker_bin=docker_bin,
+    )
+    if r.returncode != 0:
+        log(f"WARNING: Failed to enable static-site Apache conf: "
+            f"{r.stderr.strip()[:200]}")
+        # The chain is not atomic: a2enconf can succeed and then
+        # `apache2ctl graceful` fail, leaving the conf-enabled symlink in
+        # place while Apache still serves the old config. That is exactly
+        # the state ensure_static_site_conf's presence probe reads as
+        # "healthy" — so it would short-circuit forever on a conf that
+        # never took effect, recreating the silent-forever failure this
+        # pair exists to end. Back the symlink out so the probe stays
+        # honest and the next start retries.
+        try:
+            _exec_sh("a2disconf onionpress-static-site", docker_bin=docker_bin)
+        except Exception:
+            pass  # best-effort cleanup; the warning above is the signal
+        return False
+
+    log("Static-first Apache conf installed "
+        "(static generations served ahead of WordPress)")
+    return True
+
+
+def install_uploads_ini(
+    *,
+    conf_dir: str,
+    docker_bin: str = "docker",
+    log_func: Optional[Callable[[str], None]] = None,
+) -> bool:
+    """Inject the PHP limits ini into the running WordPress container at
+    provision time, as an overlay that leaves the image's own copy alone.
+
+    Same reasoning as install_static_site_conf: docker-compose.yml pulls the
+    WordPress image by digest from a registry the fork does not own, so a
+    `COPY` in our Dockerfile only reaches a container someone else built.
+    Runtime injection reuses the published image unchanged.
+
+    Why an overlay under a different name rather than overwriting: unlike
+    onionpress-static-site.conf, the image ALREADY ships
+    /usr/local/etc/php/conf.d/onionpress-uploads.ini — present, but frozen
+    at whatever limits the image was built with. PHP reads conf.d in
+    alphabetical order, last value wins, so copying our version to
+    zz-onionpress-uploads.ini overrides the image's without touching it. The
+    image's file stays pristine (an upstream revision of it is not silently
+    clobbered), and backing the injection out is a plain `rm` of a file we
+    alone own.
+
+    The reload is not optional. mod_php reads conf.d when an Apache worker
+    initialises, so `docker cp` alone leaves every live worker on the old
+    limits — verified against a real container: the copy lands, the served
+    values stay at the image's, and only `apache2ctl graceful` moves them.
+
+    `conf_dir` is the on-disk directory holding onionpress-uploads.ini — the
+    same directory install_static_site_conf reads its conf from.
+    Best-effort: a missing file or a not-yet-running container logs a
+    warning and returns False without aborting the provision run.
+    """
+    log = log_func or _noop_log
+    src = os.path.join(conf_dir, "onionpress-uploads.ini")
+    if not os.path.isfile(src):
+        log(f"WARNING: PHP limits ini not found at {src} — "
+            "large static-site uploads may exceed PHP's default limits")
+        return False
+
+    cp = _docker_cp(
+        src,
+        f"onionpress-wordpress:{UPLOADS_INI_PATH}",
+        docker_bin=docker_bin,
+    )
+    if cp.returncode != 0:
+        log(f"WARNING: Failed to copy PHP limits ini: "
+            f"{cp.stderr.strip()[:200]}")
+        return False
+
+    r = _exec_sh("apache2ctl graceful", docker_bin=docker_bin)
+    if r.returncode != 0:
+        log(f"WARNING: Failed to reload Apache for PHP limits ini: "
+            f"{r.stderr.strip()[:200]}")
+        # Copy-then-reload is not atomic, and the overlay file existing is
+        # exactly what ensure_uploads_ini's probe reads as "healthy" — so a
+        # failed reload would short-circuit every later start on limits
+        # Apache never actually loaded. Remove it so the probe stays honest
+        # and the next start retries.
+        try:
+            _exec_sh(f"rm -f {UPLOADS_INI_PATH}", docker_bin=docker_bin)
+        except Exception:
+            pass  # best-effort cleanup; the warning above is the signal
+        return False
+
+    log("PHP limits ini installed "
+        "(large static generations can be uploaded)")
+    return True
+
+
+def ensure_uploads_ini(
+    *,
+    conf_dir: str,
+    docker_bin: str = "docker",
+    log_func: Optional[Callable[[str], None]] = None,
+) -> bool:
+    """Guarantee the PHP limits overlay is present, cheaply.
+
+    The container-rootfs/volume asymmetry ensure_static_site_conf exists for
+    applies here too: /usr/local/etc/php/conf.d is rootfs, so a container
+    RECREATE drops the overlay and restores the image's lower limits, while
+    a plain restart keeps it. provision_post_install re-injects on the next
+    full start, but a launcher `start` that short-circuits on an
+    already-running stack never reaches provisioning.
+
+    The failure that leaves behind is not silent, unlike the static-site
+    one — the next large upload fails outright at the image's stale
+    limits. It is, though, indefinite: nothing else on the start path
+    would ever put the overlay back.
+
+    Cheap by design — one `test -e` on the happy path, no docker cp and no
+    Apache reload, so it is safe on every start including the fast
+    already-running path. Same deliberate tradeoff as
+    ensure_static_site_conf: it tests presence, not content, so an app
+    update shipping revised limits will NOT refresh an overlay already in
+    the container. An app update recreates the container anyway, which
+    drops the overlay entirely and lets provision_post_install install the
+    new version on the very next start.
+
+    Returns True if the overlay is present or was successfully restored.
+    Best-effort like install_uploads_ini: never raises, so it can never turn
+    a healthy start into a failed one.
+    """
+    log = log_func or _noop_log
+    try:
+        present = _exec_sh(
+            f"test -e {UPLOADS_INI_PATH}", docker_bin=docker_bin)
+        if present.returncode == 0:
+            return True
+
+        # Same rc=1 ambiguity ensure_static_site_conf splits on: `test -e`
+        # reports absence with an EMPTY stderr, while the docker CLI reports
+        # a dead daemon or a stopped container with a message ON stderr.
+        # Without the split, a stopped container claims a recreate happened
+        # and runs a copy that cannot land.
+        if present.stderr.strip():
+            log("WARNING: could not check PHP limits ini: "
+                f"{present.stderr.strip()[:200]}")
+            return False
+
+        log("PHP limits ini missing (container recreated?) — reinstalling "
+            "so large static generations can still be uploaded")
+        return install_uploads_ini(
+            conf_dir=conf_dir, docker_bin=docker_bin, log_func=log,
+        )
+    except Exception as e:  # docker missing, daemon hang, timeout
+        # Spans the reinstall as well as the probe: _docker_cp and _exec_sh
+        # raise TimeoutExpired/OSError rather than returning a non-zero rc,
+        # and this function promises callers it never raises.
+        log(f"WARNING: could not ensure PHP limits ini: {e}")
+        return False
+
+
+def ensure_static_site_conf(
+    *,
+    conf_dir: str,
+    docker_bin: str = "docker",
+    log_func: Optional[Callable[[str], None]] = None,
+) -> bool:
+    """Guarantee the static-first Apache conf is present, cheaply.
+
+    Why this is separate from install_static_site_conf: /etc/apache2 is
+    container rootfs, not a Docker volume, so the conf is destroyed by any
+    container RECREATE (compose recreate, image change, stack update); a
+    plain restart keeps it. provision_post_install normally re-injects it
+    on the next start, but a launcher `start` that short-circuits on an
+    already-running stack ("nothing to do") never reaches that
+    provisioning.
+
+    A recreate done behind the launcher's back therefore leaves the conf
+    missing indefinitely, and the failure is silent in the worst way:
+    publishes keep succeeding, and the onion just serves the WordPress
+    theme instead of the published site.
+
+    Cheap by design — one `test -e` in the container on the happy path,
+    with no docker cp and no Apache reload, so it is safe to call on every
+    start including the fast already-running path. The tradeoff is that it
+    tests presence, not content: an app update shipping a revised
+    onionpress-static-site.conf will NOT refresh a stale one already in the
+    container. That is deliberate — comparing content on every start costs
+    a docker cp plus an Apache reload, and an app update recreates the
+    container anyway (dropping the conf entirely), so provision_post_install
+    installs the new version on the very next start.
+
+    Only a launcher whose `start` can short-circuit on an already-running
+    stack needs this. The Linux launcher's `start` has no such
+    short-circuit — it always runs start_containers, which already calls
+    provision-post-install with --apache-conf-dir.
+
+    Returns True if the conf is present or was successfully restored.
+    Best-effort like install_static_site_conf: never raises, so it can
+    never turn a healthy start into a failed one.
+    """
+    log = log_func or _noop_log
+    try:
+        present = _exec_sh(
+            "test -e /etc/apache2/conf-enabled/onionpress-static-site.conf",
+            docker_bin=docker_bin,
+        )
+        if present.returncode == 0:
+            return True
+
+        # Tell "the conf is absent" apart from "I couldn't ask". `test -e`
+        # reports absence with rc=1 and an EMPTY stderr; the docker CLI
+        # reports a dead daemon or a stopped/absent container with rc=1 and
+        # a message ON stderr. Without this split, a stopped container logs
+        # the recreate-detected line below and runs a pointless copy —
+        # inverting the diagnostic value of the one line this whole
+        # function exists to emit.
+        if present.stderr.strip():
+            log("WARNING: could not check static-site Apache conf: "
+                f"{present.stderr.strip()[:200]}")
+            return False
+
+        log("Static-first Apache conf missing (container recreated?) — "
+            "reinstalling so static generations are served ahead of WordPress")
+        return install_static_site_conf(
+            conf_dir=conf_dir, docker_bin=docker_bin, log_func=log,
+        )
+    except Exception as e:  # docker missing, daemon hang, timeout
+        # Deliberately spans the reinstall as well as the probe: _docker_cp
+        # and _exec_sh raise TimeoutExpired/OSError rather than returning a
+        # non-zero rc, and this function promises callers it never raises.
+        log(f"WARNING: could not ensure static-site Apache conf: {e}")
+        return False
 
 
 def install_onionpress_theme(
@@ -616,6 +907,7 @@ def provision_post_install(
     *,
     themes_dir: str,
     plugins_dir: str,
+    conf_dir: Optional[str] = None,
     docker_bin: str = "docker",
     log_func: Optional[Callable[[str], None]] = None,
 ) -> int:
@@ -637,6 +929,16 @@ def provision_post_install(
     ensure_multisite(docker_bin=docker_bin, log_func=log)
     install_multisite_domain_map(
         plugins_dir=plugins_dir, docker_bin=docker_bin, log_func=log)
+    # Runtime-inject the Apache static-first conf so static generations
+    # shadow WordPress, and the PHP limits overlay so uploading one doesn't
+    # exceed the image's PHP limits. Only when a conf dir is supplied —
+    # callers that predate static-first serving (and don't pass one) keep
+    # the earlier behavior. Both files live in that same directory.
+    if conf_dir:
+        install_static_site_conf(
+            conf_dir=conf_dir, docker_bin=docker_bin, log_func=log)
+        install_uploads_ini(
+            conf_dir=conf_dir, docker_bin=docker_bin, log_func=log)
     install_onionpress_theme(
         themes_dir=themes_dir, plugins_dir=plugins_dir,
         docker_bin=docker_bin, log_func=log)

--- a/src/onionpress/multisite.py
+++ b/src/onionpress/multisite.py
@@ -80,6 +80,87 @@ HTACCESS_BODY = """\
 Header set Referrer-Policy "no-referrer"
 </IfModule>
 
+# Work around a Wayback replay bug: send pages uncompressed.
+#
+# This is a workaround for a defect on the archive's side, not good practice
+# in itself. Serving gzip is correct and near-universal, and the day the bug
+# is fixed this block should come back out. Keep it framed that way -- the
+# temptation when captures look wrong is to start deforming the site (inline
+# the CSS, drop external assets), and that trades a real site for a slightly
+# better archived one.
+#
+# Every replay of this site came back truncated -- to roughly a sixth of the
+# page, cut off mid-tag with no closing </html>. The replayed byte count was
+# not merely close to the gzipped size, it equalled it exactly, on every page
+# measured (2026-08-24: home 7487/43658, /illuminated-books/ 6628/34734,
+# /blogroll/ 20318/55856, /follow/ 24342/111821 -- replayed/identity, with
+# gzipped == replayed in all four). Replay serves the *decompressed* body
+# while still advertising the origin's *compressed* Content-Length, and cuts
+# to it. The stored record itself looks intact: its CDX length, ~7908 for the
+# home page, is the whole 7487-byte gzipped body plus headers.
+#
+# What this is NOT is a general "Wayback cannot do gzip" claim -- that was
+# the first read here and it is wrong. www.debian.org serves exactly the same
+# combination, gzip with an explicit Content-Length, and replays whole (18713
+# bytes, closing </html>, six stylesheet links intact). Most of the web is
+# fine. Something narrower is at work, and from outside the archive there is
+# no way to tell what; the onion capture path is the obvious suspect and the
+# only real fix is IA's. See also the `wayback` Python client, which carries
+# its own workaround for Wayback mangling Content-Encoding on mementos.
+#
+# The damage runs past the missing bytes. A page cut off before most of its
+# markup replays with almost nothing in it, so the stylesheet never loads and
+# moss's inline low-res placeholders render at their full width/height
+# attributes as giant blurred boxes.
+#
+# Proven by controlled experiment, not inference: with `SetEnv no-gzip 1` on
+# a single path, /writings/the-mental-traveller/ replayed at 13537 bytes --
+# its exact identity length, closing </html> -- while the rest of the site,
+# still gzipped, went on truncating. Reverted immediately after. The sitewide
+# form then took the home page from 7487 bytes and 2 of 19 images to 55355
+# bytes with all 19.
+#
+# Confirmed end-to-end in the archive, not just on the wire, on 2026-08-24:
+# a post-fix capture (ts 20260824101350) replays at 43658 bytes -- byte-for-
+# byte what the server sends -- with all 19 <img>, the stylesheet <link>, and
+# a closing </html>. Pre-fix captures of the same page (e.g. ts 20260824072704)
+# still replay truncated at 7487 with 2 of 19, so old records do NOT heal; the
+# page has to be re-captured after the fix to benefit.
+#
+# Two traps when checking this. (1) CDX `length` is the COMPRESSED WARC record
+# size, not the page size -- the good 43658-byte capture indexes as length 7891,
+# which looks identical to the broken 7487-byte era and is not. Replay it before
+# concluding anything. (2) CDX `statuscode` reads 204 on these records while the
+# replay serves a full 200 body, so a 204 there is not an empty capture either.
+# Both misled a session into reporting a regression that had not happened.
+#
+# So pages go out uncompressed and static assets keep their gzip. The cost
+# is small and lands where there is room for it: a page is a few tens of KB
+# next to the hundreds of KB of imagery beside it, while CSS and JS -- the
+# files that compress best and are fetched on every page -- are untouched.
+# The pattern names the documents positively: a directory URL, an .html
+# file, the feed, a WordPress page routed through index.php.
+#
+# Listing the documents rather than excluding the assets is not a style
+# choice. SetEnvIf has no regex negation: its "!" attaches to the variable
+# being unset, never to the pattern, so a rule written "!\\.(css|js)$" is a
+# regex hunting for a literal "!" and quietly never fires. That exact form
+# was tried here first and shipped an inert rule -- the config parsed, the
+# server stayed up, the pages went on being gzipped and truncated.
+#
+# The feed is in the list on purpose. It is not an asset the archive picks
+# up in passing: the sweep submits /rss.xml by name, and 17 copies of it
+# are already stored, every one cut to its gzipped length like the pages.
+#
+# Leaving the assets gzipped costs nothing today, because none of them reach
+# the archive at all. Same onion, same window, two 29-byte files with
+# identical bytes: the one served as text/html captured, the one served as
+# text/css came back "unreachable". Non-HTML over the onion is a second,
+# separate defect, and no server-side setting here reaches it.
+<IfModule mod_setenvif.c>
+SetEnvIf Request_URI "(/|\\.html?|\\.xml|\\.php)$" no-gzip=1
+</IfModule>
+
 # BEGIN WordPress Multisite
 RewriteEngine On
 RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]

--- a/tests/test_install_invariants.py
+++ b/tests/test_install_invariants.py
@@ -1231,5 +1231,35 @@ class TestScrubVerifyChecks(unittest.TestCase):
         )
 
 
+class TestUploadsIniShipsBoundedStreamingLimits(unittest.TestCase):
+    """onionpress-uploads.ini is runtime-injected into the WordPress
+    container (multisite.install_uploads_ini) so a large static-site
+    upload can land. It must bound the upload without raising
+    memory_limit: uploads arrive as multipart, which PHP streams to
+    upload_tmp_dir at constant memory, so upload_max_filesize and
+    post_max_size are the bounds that matter and a memory raise would
+    only paper over a buffering path that should not exist.
+    """
+
+    def test_uploads_ini_does_not_set_memory_limit(self):
+        ini = _read("app/Resources/docker/wordpress/onionpress-uploads.ini")
+        self.assertIsNone(
+            re.search(r"^memory_limit\s*=", ini, re.MULTILINE),
+            "onionpress-uploads.ini sets memory_limit — uploads stream as "
+            "multipart at constant memory, so a raise here means some new "
+            "path buffers the body into PHP memory and needs its own "
+            "justification.",
+        )
+
+    def test_uploads_ini_bounds_the_multipart_part(self):
+        ini = _read("app/Resources/docker/wordpress/onionpress-uploads.ini")
+        for key in ("upload_max_filesize", "post_max_size"):
+            self.assertRegex(
+                ini, r"(?m)^%s\s*=\s*\d+[GM]$" % key,
+                "onionpress-uploads.ini must keep %s — it is the size "
+                "ceiling on the streamed multipart part." % key,
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_multisite.py
+++ b/tests/test_multisite.py
@@ -196,6 +196,470 @@ class TestInstallOnionpressTheme(unittest.TestCase):
         )
 
 
+class TestInstallStaticSiteConf(unittest.TestCase):
+    """The Apache static-first conf is injected at runtime (docker cp +
+    a2enconf), NOT baked into the pulled WordPress image. See
+    install_static_site_conf's docstring for why.
+    """
+
+    def test_copies_conf_and_enables_it(self):
+        cp_calls = []
+        exec_calls = []
+
+        def fake_cp(src, dest, **kwargs):
+            cp_calls.append((src, dest))
+            return _ok()
+
+        def fake_exec(command, **kwargs):
+            exec_calls.append(command)
+            return _ok()
+
+        with mock.patch.object(multisite, "_docker_cp", side_effect=fake_cp), \
+             mock.patch.object(multisite, "_exec_sh", side_effect=fake_exec), \
+             mock.patch("os.path.isfile", return_value=True):
+            ok = multisite.install_static_site_conf(
+                conf_dir="/x/docker/wordpress", log_func=lambda _: None)
+
+        self.assertTrue(ok)
+        # Copied the conf into Apache's conf-available.
+        self.assertEqual(len(cp_calls), 1)
+        src, dest = cp_calls[0]
+        self.assertTrue(src.endswith("onionpress-static-site.conf"))
+        self.assertIn("/etc/apache2/conf-available/", dest)
+        # Enabled the module + conf and reloaded Apache in one exec.
+        self.assertEqual(len(exec_calls), 1)
+        cmd = exec_calls[0]
+        self.assertIn("a2enmod rewrite", cmd)
+        self.assertIn("a2enconf onionpress-static-site", cmd)
+        self.assertIn("apache2ctl graceful", cmd)
+
+    def test_skips_when_conf_file_missing(self):
+        logs = []
+        with mock.patch.object(multisite, "_docker_cp") as cp, \
+             mock.patch.object(multisite, "_exec_sh") as ex, \
+             mock.patch("os.path.isfile", return_value=False):
+            ok = multisite.install_static_site_conf(
+                conf_dir="/nope", log_func=logs.append)
+
+        self.assertFalse(ok)
+        cp.assert_not_called()
+        ex.assert_not_called()
+        self.assertTrue(any("not found" in s for s in logs))
+
+    def test_returns_false_when_cp_fails(self):
+        with mock.patch.object(multisite, "_docker_cp", return_value=_err()), \
+             mock.patch.object(multisite, "_exec_sh") as ex, \
+             mock.patch("os.path.isfile", return_value=True):
+            ok = multisite.install_static_site_conf(
+                conf_dir="/x", log_func=lambda _: None)
+        self.assertFalse(ok)
+        # Never tries to enable a conf it failed to copy.
+        ex.assert_not_called()
+
+    def test_backs_the_conf_out_when_the_reload_fails(self):
+        # a2enconf && apache2ctl graceful is not atomic. If the symlink is
+        # created and then the reload fails, the conf LOOKS installed to
+        # ensure_static_site_conf's presence probe while Apache is still
+        # serving the old config — so every later start short-circuits on a
+        # conf that never took effect. Undoing the symlink keeps the probe
+        # honest and lets the next start retry.
+        exec_calls = []
+
+        def fake_exec(command, **kwargs):
+            exec_calls.append(command)
+            return _err(stderr="apache2ctl: syntax error")
+
+        with mock.patch.object(multisite, "_docker_cp", return_value=_ok()), \
+             mock.patch.object(multisite, "_exec_sh", side_effect=fake_exec), \
+             mock.patch("os.path.isfile", return_value=True):
+            ok = multisite.install_static_site_conf(
+                conf_dir="/x", log_func=lambda _: None)
+
+        self.assertFalse(ok)
+        self.assertEqual(len(exec_calls), 2)
+        self.assertIn("a2disconf onionpress-static-site", exec_calls[1])
+
+    def test_reload_failure_survives_a_failing_rollback(self):
+        # The rollback is best-effort: it shells out too, and must not turn
+        # a reported failure into a raised one on the launcher's start path.
+        def fake_exec(command, **kwargs):
+            if "a2disconf" in command:
+                raise subprocess.TimeoutExpired(cmd="docker", timeout=60)
+            return _err(stderr="boom")
+
+        with mock.patch.object(multisite, "_docker_cp", return_value=_ok()), \
+             mock.patch.object(multisite, "_exec_sh", side_effect=fake_exec), \
+             mock.patch("os.path.isfile", return_value=True):
+            ok = multisite.install_static_site_conf(
+                conf_dir="/x", log_func=lambda _: None)
+
+        self.assertFalse(ok)
+
+
+class TestEnsureStaticSiteConf(unittest.TestCase):
+    """The conf lands in container rootfs, not a volume, so a container
+    recreate drops it — and the launcher's already-running fast path exits
+    before provision_post_install could put it back. ensure_static_site_conf
+    is the guard for exactly that, and it has to stay cheap when nothing is
+    wrong because it runs on every start.
+    """
+
+    def test_no_op_when_conf_already_enabled(self):
+        with mock.patch.object(multisite, "_exec_sh",
+                               return_value=_ok()) as ex, \
+             mock.patch.object(multisite, "install_static_site_conf") as inst:
+            ok = multisite.ensure_static_site_conf(
+                conf_dir="/x/docker/wordpress", log_func=lambda _: None)
+
+        self.assertTrue(ok)
+        # Just the presence probe: no reinstall, and — the point of the
+        # cheap path — no Apache reload on an already-healthy start.
+        inst.assert_not_called()
+        self.assertEqual(len(ex.call_args_list), 1)
+        self.assertIn("conf-enabled/onionpress-static-site.conf",
+                      ex.call_args_list[0].args[0])
+
+    def test_reinstalls_when_conf_missing(self):
+        # `test -e` on a missing file: rc=1 with NOTHING on stderr. That
+        # empty stderr is load-bearing — see the docker-error test below.
+        with mock.patch.object(multisite, "_exec_sh",
+                               return_value=_err(stderr="")), \
+             mock.patch.object(multisite, "install_static_site_conf",
+                               return_value=True) as inst:
+            ok = multisite.ensure_static_site_conf(
+                conf_dir="/x/docker/wordpress", docker_bin="/b/docker",
+                log_func=lambda _: None)
+
+        self.assertTrue(ok)
+        inst.assert_called_once()
+        self.assertEqual(inst.call_args.kwargs.get("conf_dir"),
+                         "/x/docker/wordpress")
+        # The launcher passes a bundled docker binary; losing it here would
+        # send the repair to a docker that may not be on PATH.
+        self.assertEqual(inst.call_args.kwargs.get("docker_bin"), "/b/docker")
+
+    def test_docker_error_is_not_mistaken_for_a_missing_conf(self):
+        # A stopped container or dead daemon also exits non-zero, but writes
+        # to stderr. Treating that as "conf missing" would log the
+        # recreate-detected line and run a doomed copy — turning the one
+        # diagnostic this function exists to emit into a false alarm.
+        logged = []
+        with mock.patch.object(
+                multisite, "_exec_sh",
+                return_value=_err(stderr="Error: No such container")), \
+             mock.patch.object(multisite, "install_static_site_conf") as inst:
+            ok = multisite.ensure_static_site_conf(
+                conf_dir="/x", log_func=logged.append)
+
+        self.assertFalse(ok)
+        inst.assert_not_called()
+        self.assertTrue(any("could not check" in m for m in logged), logged)
+        self.assertFalse(any("recreated" in m for m in logged), logged)
+
+    def test_never_raises_when_docker_unavailable(self):
+        # This runs on the launcher's start path, so an exception escaping
+        # here would turn a perfectly healthy already-running stack into a
+        # failed `start`.
+        with mock.patch.object(multisite, "_exec_sh",
+                               side_effect=OSError("docker gone")), \
+             mock.patch.object(multisite, "install_static_site_conf") as inst:
+            ok = multisite.ensure_static_site_conf(
+                conf_dir="/x", log_func=lambda _: None)
+
+        self.assertFalse(ok)
+        inst.assert_not_called()
+
+    def test_never_raises_when_the_repair_itself_raises(self):
+        # The probe is not the only thing that can throw: the reinstall
+        # shells out too, and _docker_cp/_exec_sh raise TimeoutExpired on a
+        # wedged daemon rather than returning non-zero. A `try` around only
+        # the probe would let that escape into the launcher.
+        with mock.patch.object(multisite, "_exec_sh",
+                               return_value=_err(stderr="")), \
+             mock.patch.object(
+                 multisite, "install_static_site_conf",
+                 side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=60)):
+            ok = multisite.ensure_static_site_conf(
+                conf_dir="/x", log_func=lambda _: None)
+
+        self.assertFalse(ok)
+
+    def test_reports_failure_when_the_repair_fails(self):
+        # A failed reinstall must not be laundered into a success — the
+        # publisher would go on publishing to a site the onion never serves.
+        with mock.patch.object(multisite, "_exec_sh",
+                               return_value=_err(stderr="")), \
+             mock.patch.object(multisite, "install_static_site_conf",
+                               return_value=False):
+            ok = multisite.ensure_static_site_conf(
+                conf_dir="/x", log_func=lambda _: None)
+
+        self.assertFalse(ok)
+
+
+class TestUploadsIniOverlayPath(unittest.TestCase):
+    """The overlay's filename is the whole mechanism, so pin it. Unlike the
+    static-site conf, the WordPress image already ships an
+    onionpress-uploads.ini — present, but frozen at whatever limits the
+    image was built with. We override it rather than overwrite it, which
+    only works because PHP reads conf.d alphabetically and takes the last
+    value it sees.
+    """
+
+    def test_overlay_sorts_after_the_images_own_ini(self):
+        directory, _, name = multisite.UPLOADS_INI_PATH.rpartition("/")
+        self.assertEqual(directory, "/usr/local/etc/php/conf.d")
+        self.assertGreater(
+            name, "onionpress-uploads.ini",
+            "The overlay must sort AFTER the image's own ini or PHP reads "
+            "it first and the image's stale limits win.",
+        )
+
+    def test_overlay_does_not_overwrite_the_images_own_ini(self):
+        self.assertNotEqual(
+            multisite.UPLOADS_INI_PATH,
+            "/usr/local/etc/php/conf.d/onionpress-uploads.ini",
+            "Writing over the image's own file would silently clobber an "
+            "upstream revision of it, and leaves nothing clean to roll back.",
+        )
+
+
+class TestInstallUploadsIni(unittest.TestCase):
+    """The PHP limits ini is injected at runtime for the same reason the
+    static-site conf is — the WordPress image is pulled by digest from a
+    registry the fork does not own, so a Dockerfile COPY only reaches
+    whoever builds it. See install_uploads_ini's docstring.
+    """
+
+    def test_copies_overlay_and_reloads_apache(self):
+        cp_calls = []
+        exec_calls = []
+
+        with mock.patch.object(
+                multisite, "_docker_cp",
+                side_effect=lambda s, d, **k: cp_calls.append((s, d)) or _ok()), \
+             mock.patch.object(
+                multisite, "_exec_sh",
+                side_effect=lambda c, **k: exec_calls.append(c) or _ok()), \
+             mock.patch("os.path.isfile", return_value=True):
+            ok = multisite.install_uploads_ini(
+                conf_dir="/x/docker/wordpress", log_func=lambda _: None)
+
+        self.assertTrue(ok)
+        self.assertEqual(len(cp_calls), 1)
+        src, dest = cp_calls[0]
+        self.assertTrue(src.endswith("onionpress-uploads.ini"))
+        self.assertEqual(dest, f"onionpress-wordpress:{multisite.UPLOADS_INI_PATH}")
+        # mod_php reads conf.d when a worker initialises, so the copy alone
+        # leaves every live worker on the image's limits. Verified against
+        # a real container: the served values only move after the graceful.
+        self.assertEqual(exec_calls, ["apache2ctl graceful"])
+
+    def test_skips_when_ini_missing(self):
+        logs = []
+        with mock.patch.object(multisite, "_docker_cp") as cp, \
+             mock.patch.object(multisite, "_exec_sh") as ex, \
+             mock.patch("os.path.isfile", return_value=False):
+            ok = multisite.install_uploads_ini(
+                conf_dir="/nope", log_func=logs.append)
+
+        self.assertFalse(ok)
+        cp.assert_not_called()
+        ex.assert_not_called()
+        self.assertTrue(any("not found" in s for s in logs))
+
+    def test_returns_false_when_cp_fails(self):
+        with mock.patch.object(multisite, "_docker_cp", return_value=_err()), \
+             mock.patch.object(multisite, "_exec_sh") as ex, \
+             mock.patch("os.path.isfile", return_value=True):
+            ok = multisite.install_uploads_ini(
+                conf_dir="/x", log_func=lambda _: None)
+        self.assertFalse(ok)
+        # Never reloads Apache for a file that failed to land.
+        ex.assert_not_called()
+
+    def test_removes_the_overlay_when_the_reload_fails(self):
+        # Copy-then-reload is not atomic. A copied-but-unloaded overlay is
+        # exactly what ensure_uploads_ini's presence probe reads as healthy,
+        # so leaving it behind would short-circuit every later start on
+        # limits Apache never applied.
+        exec_calls = []
+
+        def fake_exec(command, **kwargs):
+            exec_calls.append(command)
+            return _err(stderr="apache2ctl: syntax error")
+
+        with mock.patch.object(multisite, "_docker_cp", return_value=_ok()), \
+             mock.patch.object(multisite, "_exec_sh", side_effect=fake_exec), \
+             mock.patch("os.path.isfile", return_value=True):
+            ok = multisite.install_uploads_ini(
+                conf_dir="/x", log_func=lambda _: None)
+
+        self.assertFalse(ok)
+        self.assertEqual(len(exec_calls), 2)
+        self.assertIn(f"rm -f {multisite.UPLOADS_INI_PATH}", exec_calls[1])
+
+    def test_reload_failure_survives_a_failing_rollback(self):
+        # The rollback shells out too, and must not turn a reported failure
+        # into a raised one on the launcher's start path.
+        def fake_exec(command, **kwargs):
+            if command.startswith("rm -f"):
+                raise subprocess.TimeoutExpired(cmd="docker", timeout=60)
+            return _err(stderr="boom")
+
+        with mock.patch.object(multisite, "_docker_cp", return_value=_ok()), \
+             mock.patch.object(multisite, "_exec_sh", side_effect=fake_exec), \
+             mock.patch("os.path.isfile", return_value=True):
+            ok = multisite.install_uploads_ini(
+                conf_dir="/x", log_func=lambda _: None)
+
+        self.assertFalse(ok)
+
+
+class TestEnsureUploadsIni(unittest.TestCase):
+    """conf.d is container rootfs, so a recreate drops the overlay and
+    restores the image's lower limits — and the launcher's
+    already-running fast path exits before provisioning could put it back.
+    Has to stay cheap: it runs on every start.
+    """
+
+    def test_no_op_when_overlay_already_present(self):
+        with mock.patch.object(multisite, "_exec_sh",
+                               return_value=_ok()) as ex, \
+             mock.patch.object(multisite, "install_uploads_ini") as inst:
+            ok = multisite.ensure_uploads_ini(
+                conf_dir="/x/docker/wordpress", log_func=lambda _: None)
+
+        self.assertTrue(ok)
+        # Just the probe: no copy, and — the point of the cheap path — no
+        # Apache reload on an already-healthy start.
+        inst.assert_not_called()
+        self.assertEqual(len(ex.call_args_list), 1)
+        self.assertIn(multisite.UPLOADS_INI_PATH, ex.call_args_list[0].args[0])
+
+    def test_reinstalls_when_overlay_missing(self):
+        # `test -e` on a missing file: rc=1 with NOTHING on stderr. That
+        # empty stderr is load-bearing — see the docker-error test below.
+        with mock.patch.object(multisite, "_exec_sh",
+                               return_value=_err(stderr="")), \
+             mock.patch.object(multisite, "install_uploads_ini",
+                               return_value=True) as inst:
+            ok = multisite.ensure_uploads_ini(
+                conf_dir="/x/docker/wordpress", docker_bin="/b/docker",
+                log_func=lambda _: None)
+
+        self.assertTrue(ok)
+        inst.assert_called_once()
+        self.assertEqual(inst.call_args.kwargs.get("conf_dir"),
+                         "/x/docker/wordpress")
+        # The launcher passes a bundled docker binary; losing it here would
+        # send the repair to a docker that may not be on PATH.
+        self.assertEqual(inst.call_args.kwargs.get("docker_bin"), "/b/docker")
+
+    def test_docker_error_is_not_mistaken_for_a_missing_overlay(self):
+        # A stopped container or dead daemon also exits non-zero, but writes
+        # to stderr. Treating that as "overlay missing" would claim a
+        # recreate happened and run a copy that cannot land.
+        logged = []
+        with mock.patch.object(
+                multisite, "_exec_sh",
+                return_value=_err(stderr="Error: No such container")), \
+             mock.patch.object(multisite, "install_uploads_ini") as inst:
+            ok = multisite.ensure_uploads_ini(conf_dir="/x",
+                                              log_func=logged.append)
+
+        self.assertFalse(ok)
+        inst.assert_not_called()
+        self.assertTrue(any("could not check" in m for m in logged), logged)
+        self.assertFalse(any("recreated" in m for m in logged), logged)
+
+    def test_never_raises_when_the_probe_raises(self):
+        # An exception escaping here turns a perfectly healthy
+        # already-running stack into a failed `start`.
+        with mock.patch.object(multisite, "_exec_sh",
+                               side_effect=OSError("docker gone")), \
+             mock.patch.object(multisite, "install_uploads_ini") as inst:
+            ok = multisite.ensure_uploads_ini(conf_dir="/x",
+                                              log_func=lambda _: None)
+
+        self.assertFalse(ok)
+        inst.assert_not_called()
+
+    def test_never_raises_when_the_repair_raises(self):
+        # The probe is not the only thing that can throw: the repair shells
+        # out too, and _docker_cp/_exec_sh raise TimeoutExpired on a wedged
+        # daemon rather than returning non-zero. A `try` around only the
+        # probe would let that escape into the launcher.
+        with mock.patch.object(multisite, "_exec_sh",
+                               return_value=_err(stderr="")), \
+             mock.patch.object(
+                 multisite, "install_uploads_ini",
+                 side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=60)):
+            ok = multisite.ensure_uploads_ini(conf_dir="/x",
+                                              log_func=lambda _: None)
+
+        self.assertFalse(ok)
+
+    def test_reports_failure_when_the_repair_fails(self):
+        # A failed reinstall must not be laundered into a success — the
+        # next large upload would fail at the image's stale limits with
+        # nothing in the log to say the repair had been attempted and lost.
+        with mock.patch.object(multisite, "_exec_sh",
+                               return_value=_err(stderr="")), \
+             mock.patch.object(multisite, "install_uploads_ini",
+                               return_value=False):
+            ok = multisite.ensure_uploads_ini(conf_dir="/x",
+                                              log_func=lambda _: None)
+
+        self.assertFalse(ok)
+
+
+class TestProvisionInjectsStaticConf(unittest.TestCase):
+    """provision_post_install only injects the runtime confs when a conf_dir
+    is supplied — earlier callers that omit it keep the old behavior. Both
+    the static-site conf and the PHP limits overlay come from that one
+    directory and share the guard.
+    """
+
+    def _patch_all_but_conf(self):
+        def fake(**kwargs):
+            return True
+        return [
+            mock.patch.object(multisite, "ensure_multisite", fake),
+            mock.patch.object(multisite, "install_multisite_domain_map", fake),
+            mock.patch.object(multisite, "install_onionpress_theme", fake),
+            mock.patch.object(multisite, "fix_onionpress_permissions", fake),
+            mock.patch.object(multisite, "fix_wordpress_uploads_permissions", fake),
+            mock.patch.object(multisite, "write_shared_onion_address", fake),
+        ]
+
+    def test_injects_when_conf_dir_given(self):
+        patches = self._patch_all_but_conf()
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+        with mock.patch.object(multisite, "install_static_site_conf") as static, \
+             mock.patch.object(multisite, "install_uploads_ini") as ini:
+            multisite.provision_post_install(
+                themes_dir="/t", plugins_dir="/p",
+                conf_dir="/d/docker/wordpress")
+        for inj in (static, ini):
+            inj.assert_called_once()
+            self.assertEqual(inj.call_args.kwargs.get("conf_dir"),
+                             "/d/docker/wordpress")
+
+    def test_skips_when_no_conf_dir(self):
+        patches = self._patch_all_but_conf()
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+        with mock.patch.object(multisite, "install_static_site_conf") as static, \
+             mock.patch.object(multisite, "install_uploads_ini") as ini:
+            multisite.provision_post_install(themes_dir="/t", plugins_dir="/p")
+        static.assert_not_called()
+        ini.assert_not_called()
+
+
 class TestMuPluginsList(unittest.TestCase):
     """The list of bundled mu-plugins lives in MU_PLUGINS at module scope
     so Mac and Linux see the same set. Catch the easy "added a plugin

--- a/tests/test_multisite.py
+++ b/tests/test_multisite.py
@@ -9,6 +9,7 @@ orchestration glue: right wp-cli calls in the right order, right
 docker cp invocations, right error handling.
 """
 
+import re
 import subprocess
 import unittest
 from unittest import mock
@@ -794,6 +795,70 @@ class TestEnsureArchiveS3Keys(unittest.TestCase):
             result = multisite.ensure_archive_s3_keys(log_func=logs.append)
         self.assertFalse(result)
         self.assertTrue(any("Could not reach archive.org" in s for s in logs))
+
+
+class TestPagesGoOutUncompressed(unittest.TestCase):
+    """Wayback stores our pages truncated to their gzipped length, so
+    anything the sweep submits by name must be served uncompressed while
+    the assets beside it keep their gzip. Both halves matter: drop the
+    first and captures stay cut off mid-tag, drop the second and every
+    reader pays for CSS and JS that compress 5x.
+
+    The regex is read out of HTACCESS_BODY rather than retyped, so the
+    test cannot agree with a copy of the rule the server never sees.
+    """
+
+    def _no_gzip_pattern(self):
+        m = re.search(r'SetEnvIf Request_URI "([^"]+)" no-gzip=1',
+                      multisite.HTACCESS_BODY)
+        self.assertIsNotNone(m, "HTACCESS_BODY must carry the no-gzip rule")
+        pattern = m.group(1)
+        # SetEnvIf cannot negate a pattern -- a leading "!" would be matched
+        # as a literal character and the rule would never fire. Catching it
+        # here is the difference between a red test and a silently inert
+        # server config.
+        self.assertFalse(
+            pattern.startswith("!"),
+            "SetEnvIf has no regex negation; list the documents positively",
+        )
+        return re.compile(pattern)
+
+    def _uncompressed(self, pattern, url):
+        """no-gzip is set on the URLs the pattern matches."""
+        return pattern.search(url) is not None
+
+    def test_documents_the_sweep_submits_are_uncompressed(self):
+        pattern = self._no_gzip_pattern()
+        for url in (
+            "/",
+            "/illuminated-books/",
+            "/illuminated-books/songs-of-experience/the-tyger/",
+            "/index.html",
+            "/rss.xml",          # the sweep submits the feed by name
+            "/sitemap.xml",      # and reads it to find the pages
+            "/index.php",
+        ):
+            with self.subTest(url=url):
+                self.assertTrue(
+                    self._uncompressed(pattern, url),
+                    f"{url} is archived by name and must go out uncompressed",
+                )
+
+    def test_assets_keep_their_gzip(self):
+        pattern = self._no_gzip_pattern()
+        for url in (
+            "/_moss/style.c3fa146a646b7866.css",
+            "/_moss/js/theme.e39f3b537f972275.js",
+            "/assets/songs-of-experience/the-tyger.jpg",
+            "/assets/songs-of-experience/the-tyger.w800.webp",
+            "/assets/favicon.svg",
+            "/assets/favicon-32.png",
+        ):
+            with self.subTest(url=url):
+                self.assertFalse(
+                    self._uncompressed(pattern, url),
+                    f"{url} compresses well and is not submitted by name",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Part 3 of the series in #277. 

Apache serves a published static site from the current-generation symlink when one exists, and falls through to WordPress for everything else. WordPress keeps answering for admin, auto-login, and any path the static site doesn't cover. With no static site published, behavior is exactly today's.

- conf is injected at runtime (`docker cp` + `a2enconf`), and repaired after a container recreate, so WordPress image is reused unchanged.
- `--apache-conf-dir` is honored on all provision paths.
- Static pages are served uncompressed. Wayback's replay of a gzip capture serves the decompressed body at the compressed Content-Length, so the browser cuts the page short; uncompressed, every capture comes back whole. Confirmed against the live archive; the code marks it as a workaround for the replay bug.

Any static content placed at the current-generation path is served this way; the receiver that populates it arrives in part 4.

